### PR TITLE
Added directive reinitialization for upload-scans-selector

### DIFF
--- a/frontend/src/app/components/movie-viewer/movie-viewer.component.html
+++ b/frontend/src/app/components/movie-viewer/movie-viewer.component.html
@@ -1,0 +1,15 @@
+<div id="markerWrapper">
+  <img #image id="markerBackgroundImage" width="600" height="600"/>
+  <canvas #canvas id="markerCanvas" width="600" height="600"></canvas>
+  <mat-slider #slider id="markerSlider"
+              [disabled]="false"
+              [max]="10"
+              [min]="0"
+              [step]="1"
+              [thumb-label]="true"
+              [tick-interval]="1"
+              [value]="this.currentSlice"
+              [vertical]="true">
+  </mat-slider>
+</div>
+

--- a/frontend/src/app/components/movie-viewer/movie-viewer.component.scss
+++ b/frontend/src/app/components/movie-viewer/movie-viewer.component.scss
@@ -1,0 +1,28 @@
+@import '../../../app-theme.scss';
+
+$canvas-size: 600px;
+
+#markerCanvas {
+  width: $canvas-size;
+  height: $canvas-size;
+  position: absolute;
+  user-select: none;
+}
+
+#markerBackgroundImage {
+  @extend #markerCanvas;
+  background-color: grey;
+}
+
+#markerSlider {
+  position: absolute;
+  left: $canvas-size;
+  height: $canvas-size;
+}
+
+#markerAcceptButton {
+  position: absolute;
+  left: $canvas-size / 2;
+  top: $canvas-size;
+}
+

--- a/frontend/src/app/components/movie-viewer/movie-viewer.component.spec.ts
+++ b/frontend/src/app/components/movie-viewer/movie-viewer.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScanViewerComponent } from './scan-viewer.component';
+
+describe('ScanViewerComponent', () => {
+  let component: ScanViewerComponent;
+  let fixture: ComponentFixture<ScanViewerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ScanViewerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ScanViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/movie-viewer/movie-viewer.component.ts
+++ b/frontend/src/app/components/movie-viewer/movie-viewer.component.ts
@@ -1,0 +1,170 @@
+import {Component, HostListener, OnInit, ViewChild, ElementRef} from '@angular/core';
+import {MarkerSlice} from '../../model/MarkerSlice';
+import {Subject} from 'rxjs/Subject';
+import {ScanMetadata} from '../../model/ScanMetadata';
+import {MatSlider} from '@angular/material';
+import {Selector} from '../selectors/Selector';
+import {SliceSelection} from '../../model/SliceSelection';
+
+@Component({
+  selector: 'app-scan-viewer',
+  templateUrl: './scan-viewer.component.html',
+  styleUrls: ['./scan-viewer.component.scss']
+})
+export class ScanViewerComponent implements OnInit {
+
+  currentImage: HTMLImageElement;
+
+  @ViewChild('image')
+  set viewImage(viewElement: ElementRef) {
+    this.currentImage = viewElement.nativeElement;
+  }
+
+  canvas: HTMLCanvasElement;
+
+  @ViewChild('canvas')
+  set viewCanvas(viewElement: ElementRef) {
+    this.canvas = viewElement.nativeElement;
+  }
+
+  @ViewChild('slider') slider: MatSlider;
+
+  public scanMetadata: ScanMetadata;
+  public slices: Map<number, MarkerSlice>;
+  protected _currentSlice;
+
+  public hasArchivedSelections: boolean;
+
+  public observableSliceRequest: Subject<number>;
+  protected sliceBatchSize: number;
+
+  protected selector: Selector<SliceSelection>;
+
+  constructor() {
+  }
+
+  public setSelector(newSelector: Selector<SliceSelection>) {
+    this.selector = newSelector;
+  }
+
+  public setArchivedSelections(selections: Array<SliceSelection>): void {
+    console.log('ScanViewer | setArchivedSelections: ', selections);
+    const normalizedSelections: Array<SliceSelection> = this.selector.formArchivedSelections(selections);
+    this.selector.archiveSelections(normalizedSelections);
+  }
+
+  public getCanvas(): HTMLCanvasElement {
+    return this.canvas;
+  }
+
+  get currentSlice() {
+    return this._currentSlice;
+  }
+
+  public clearData(): void {
+    this.slices = new Map<number, MarkerSlice>();
+    this._currentSlice = undefined;
+    this.selector.clearData();
+  }
+
+  public feedData(newSlice: MarkerSlice): void {
+    console.log('Marker | feedData: ', newSlice);
+    if (!this._currentSlice) {
+      this._currentSlice = newSlice.index;
+      this.selector.updateCurrentSlice(this._currentSlice);
+    }
+    this.addSlice(newSlice);
+    this.updateSliderRange();
+  }
+
+  protected updateSliderRange(): void {
+    const sortedKeys: number[] = Array.from(this.slices.keys()).sort((a: number, b: number) => {
+      return a - b;
+    });
+    console.log('MarkerComponent | updateSliderRange | sortedKeys: ', sortedKeys);
+
+    this.slider.min = sortedKeys[0];
+    this.slider.max = sortedKeys[sortedKeys.length - 1];
+  }
+
+  protected addSlice(newSlice: MarkerSlice) {
+    this.slices.set(newSlice.index, newSlice);
+    if (this.slices.size === 1) {
+      this.setCanvasImage();
+    }
+  }
+
+  public setScanMetadata(scanMetadata: ScanMetadata): void {
+    this.scanMetadata = scanMetadata;
+    // this.slider.max = scanMetadata.numberOfSlices;
+  }
+
+  public hookUpSliceObserver(sliceBatchSize: number): Promise<boolean> {
+    this.sliceBatchSize = sliceBatchSize;
+    return new Promise((resolve) => {
+      this.observableSliceRequest = new Subject<number>();
+      resolve(true);
+    });
+  }
+
+  ngOnInit() {
+    console.log('Marker init');
+    console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider);
+
+    this.slices = new Map<number, MarkerSlice>();
+
+    this.initializeCanvas();
+
+    this.setCanvasImage();
+
+    this.slider.registerOnChange((sliderValue: number) => {
+      console.log('Marker init | slider change: ', sliderValue);
+      this.selector.updateCurrentSlice(sliderValue);
+
+      this.requestSlicesIfNeeded(sliderValue);
+
+      this.changeMarkerImage(sliderValue);
+      this.selector.drawPreviousSelections();
+    });
+  }
+
+  protected requestSlicesIfNeeded(sliderValue: number): void {
+    console.log('Marker | requestSlicesIfNeeded sliderValue: ', sliderValue);
+    let requestSliceIndex;
+    if (this.slider.max === sliderValue) {
+      requestSliceIndex = sliderValue + 1;
+      console.log('Marker | requestSlicesIfNeeded more (higher indexes): ', requestSliceIndex);
+      this.observableSliceRequest.next(requestSliceIndex);
+    }
+    if (this.slider.min === sliderValue) {
+      requestSliceIndex = sliderValue - this.sliceBatchSize;
+      console.log('Marker | requestSlicesIfNeeded more (lower indexes): ', requestSliceIndex);
+      this.observableSliceRequest.next(requestSliceIndex);
+    }
+  }
+
+  protected initializeCanvas(): void {
+    this.selector.updateCanvasPosition(this.canvas.getBoundingClientRect());
+  }
+
+  @HostListener('window:resize', [])
+  protected updateCanvasPositionOnWindowResize(): void {
+    this.selector.updateCanvasPosition(this.canvas.getBoundingClientRect());
+  }
+
+  protected changeMarkerImage(sliceID: number): void {
+    this.selector.addCurrentSelection();
+
+    this._currentSlice = sliceID;
+    this.selector.updateCurrentSlice(this._currentSlice);
+
+    this.selector.clearCanvasSelection();
+    this.setCanvasImage();
+  }
+
+  protected setCanvasImage(): void {
+    if (this.slices.has(this._currentSlice)) {
+      this.currentImage.src = this.slices.get(this._currentSlice).source;
+    }
+  }
+}

--- a/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
+++ b/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
@@ -33,7 +33,7 @@ export class UploadScansSelectorComponent {
       };
       return;
     }
-    
+
     // User selected multiple scans for upload, so let's group them into the Scans
     this.numberOfScans = 0;
     this.numberOfSlices = 0;
@@ -68,5 +68,13 @@ export class UploadScansSelectorComponent {
 
   selectFile() {
     this.nativeInputFile.nativeElement.click();
+  }
+
+  public reinitialize(): void {
+    this._files = [];
+
+    this.numberOfSlices = 0;
+    this.numberOfScans = 0;
+    this.scans = {};
   }
 }

--- a/frontend/src/app/pages/upload-page/upload-page.component.html
+++ b/frontend/src/app/pages/upload-page/upload-page.component.html
@@ -70,7 +70,7 @@
             <!--<img src="../../../assets/img/example_upload_single_scan.png">-->
           </mat-card-content>
           <mat-card-actions>
-            <upload-scans-selector (onFileSelect)="chooseFiles($event)" [multipleScans]="false" style="float: left;"></upload-scans-selector>
+            <upload-scans-selector #uploadSingleScanSelector (onFileSelect)="chooseFiles($event)" [multipleScans]="false" style="float: left;"></upload-scans-selector>
             <button mat-raised-button color="primary" (click)="uploadFiles()" style="float: right;" matStepperNext>Upload!</button>
             <div class="clearfix"></div>
           </mat-card-actions>
@@ -88,7 +88,7 @@
             <!--<img src="../../../assets/img/example_upload_multiple_scans.png">-->
           </mat-card-content>
           <mat-card-actions>
-            <upload-scans-selector (onFileSelect)="chooseFiles($event)" [multipleScans]="true" style="float: left;"></upload-scans-selector>
+            <upload-scans-selector #uploadMultipleScansSelector (onFileSelect)="chooseFiles($event)" [multipleScans]="true" style="float: left;"></upload-scans-selector>
             <button mat-raised-button color="primary" (click)="uploadFiles()" style="float: right;" matStepperNext>Upload!</button>
             <div class="clearfix"></div>
           </mat-card-actions>

--- a/frontend/src/app/pages/upload-page/upload-page.component.ts
+++ b/frontend/src/app/pages/upload-page/upload-page.component.ts
@@ -3,6 +3,7 @@ import { MatHorizontalStepper, MatStep } from '@angular/material';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 
 import { ScanService } from '../../services/scan.service';
+import {UploadScansSelectorComponent} from "../../components/upload-scans-selector/upload-scans-selector.component";
 
 
 enum UploadMode {
@@ -24,6 +25,8 @@ export class UploadPageComponent implements OnInit {
   @ViewChild('chooseFilesStep') chooseFilesStep: MatStep;
   @ViewChild('sendingFilesStep') sendingFilesStep: MatStep;
   @ViewChild('uploadCompletedStep') uploadCompletedStep: MatStep;
+  @ViewChild('uploadSingleScanSelector') uploadSingleScanSelector: UploadScansSelectorComponent;
+  @ViewChild('uploadMultipleScansSelector') uploadMultipleScansSelector: UploadScansSelectorComponent;
 
   scans: object = {};
   numberOfScans: number = 0;
@@ -99,8 +102,23 @@ export class UploadPageComponent implements OnInit {
 
   restart() {
     this.chooseCategoryFormGroup.reset();
+    this.chooseModeFormGroup.reset();
+    this.chooseFilesFormGroup.reset();
+    this.sendingFilesFormGroup.reset();
+    this.uploadCompletedFormGroup.reset();
+
+    if(this.uploadSingleScanSelector) {
+      this.uploadSingleScanSelector.reinitialize();
+    }
+
+    if(this.uploadMultipleScansSelector) {
+      this.uploadMultipleScansSelector.reinitialize();
+    }
+
     this.scans = {};
     this.numberOfScans = 0;
+    this.totalNumberOfSlices = 0;
+    this.slicesSent = 0;
     this.totalNumberOfSlices = 0;
 
     this.stepper.selectedIndex = 0;

--- a/frontend/src/app/pages/upload-page/upload-page.component.ts
+++ b/frontend/src/app/pages/upload-page/upload-page.component.ts
@@ -119,7 +119,6 @@ export class UploadPageComponent implements OnInit {
     this.numberOfScans = 0;
     this.totalNumberOfSlices = 0;
     this.slicesSent = 0;
-    this.totalNumberOfSlices = 0;
 
     this.stepper.selectedIndex = 0;
     this.chooseModeStep.completed = false;


### PR DESCRIPTION
Fixes `Upload scans wizard does not restart properly` #26

## Proposed Changes

  - Added reinitialization method for `UploadScansSelectorComponent`
  - Added ViewChild references to `UploadScansSelectorComponent` in `UploadPageComponent`
  - Reset rest of the form groups in controller (just to be sure...)
  - Reset rest of the variables used on the view

