### PR TITLE
Added directive reinitialization for upload-scans-selector

### DIFF
--- a/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
+++ b/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
@@ -33,7 +33,7 @@ export class UploadScansSelectorComponent {
       };
       return;
     }
-    
+
     // User selected multiple scans for upload, so let's group them into the Scans
     this.numberOfScans = 0;
     this.numberOfSlices = 0;
@@ -68,5 +68,13 @@ export class UploadScansSelectorComponent {
 
   selectFile() {
     this.nativeInputFile.nativeElement.click();
+  }
+
+  public reinitialize(): void {
+    this._files = [];
+
+    this.numberOfSlices = 0;
+    this.numberOfScans = 0;
+    this.scans = {};
   }
 }

--- a/frontend/src/app/pages/upload-page/upload-page.component.html
+++ b/frontend/src/app/pages/upload-page/upload-page.component.html
@@ -70,7 +70,7 @@
             <!--<img src="../../../assets/img/example_upload_single_scan.png">-->
           </mat-card-content>
           <mat-card-actions>
-            <upload-scans-selector (onFileSelect)="chooseFiles($event)" [multipleScans]="false" style="float: left;"></upload-scans-selector>
+            <upload-scans-selector #uploadSingleScanSelector (onFileSelect)="chooseFiles($event)" [multipleScans]="false" style="float: left;"></upload-scans-selector>
             <button mat-raised-button color="primary" (click)="uploadFiles()" style="float: right;" matStepperNext>Upload!</button>
             <div class="clearfix"></div>
           </mat-card-actions>
@@ -88,7 +88,7 @@
             <!--<img src="../../../assets/img/example_upload_multiple_scans.png">-->
           </mat-card-content>
           <mat-card-actions>
-            <upload-scans-selector (onFileSelect)="chooseFiles($event)" [multipleScans]="true" style="float: left;"></upload-scans-selector>
+            <upload-scans-selector #uploadMultipleScansSelector (onFileSelect)="chooseFiles($event)" [multipleScans]="true" style="float: left;"></upload-scans-selector>
             <button mat-raised-button color="primary" (click)="uploadFiles()" style="float: right;" matStepperNext>Upload!</button>
             <div class="clearfix"></div>
           </mat-card-actions>

--- a/frontend/src/app/pages/upload-page/upload-page.component.ts
+++ b/frontend/src/app/pages/upload-page/upload-page.component.ts
@@ -3,6 +3,7 @@ import { MatHorizontalStepper, MatStep } from '@angular/material';
 import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
 
 import { ScanService } from '../../services/scan.service';
+import {UploadScansSelectorComponent} from "../../components/upload-scans-selector/upload-scans-selector.component";
 
 
 enum UploadMode {
@@ -24,6 +25,8 @@ export class UploadPageComponent implements OnInit {
   @ViewChild('chooseFilesStep') chooseFilesStep: MatStep;
   @ViewChild('sendingFilesStep') sendingFilesStep: MatStep;
   @ViewChild('uploadCompletedStep') uploadCompletedStep: MatStep;
+  @ViewChild('uploadSingleScanSelector') uploadSingleScanSelector: UploadScansSelectorComponent;
+  @ViewChild('uploadMultipleScansSelector') uploadMultipleScansSelector: UploadScansSelectorComponent;
 
   scans: object = {};
   numberOfScans: number = 0;
@@ -99,8 +102,23 @@ export class UploadPageComponent implements OnInit {
 
   restart() {
     this.chooseCategoryFormGroup.reset();
+    this.chooseModeFormGroup.reset();
+    this.chooseFilesFormGroup.reset();
+    this.sendingFilesFormGroup.reset();
+    this.uploadCompletedFormGroup.reset();
+
+    if(this.uploadSingleScanSelector) {
+      this.uploadSingleScanSelector.reinitialize();
+    }
+
+    if(this.uploadMultipleScansSelector) {
+      this.uploadMultipleScansSelector.reinitialize();
+    }
+
     this.scans = {};
     this.numberOfScans = 0;
+    this.totalNumberOfSlices = 0;
+    this.slicesSent = 0;
     this.totalNumberOfSlices = 0;
 
     this.stepper.selectedIndex = 0;

--- a/frontend/src/app/pages/upload-page/upload-page.component.ts
+++ b/frontend/src/app/pages/upload-page/upload-page.component.ts
@@ -119,7 +119,6 @@ export class UploadPageComponent implements OnInit {
     this.numberOfScans = 0;
     this.totalNumberOfSlices = 0;
     this.slicesSent = 0;
-    this.totalNumberOfSlices = 0;
 
     this.stepper.selectedIndex = 0;
     this.chooseModeStep.completed = false;


### PR DESCRIPTION
Fixes `Upload scans wizard does not restart properly` #26

## Proposed Changes

  - Added reinitialization method for `UploadScansSelectorComponent`
  - Added ViewChild references to `UploadScansSelectorComponent` in `UploadPageComponent`
  - Reset rest of the form groups in controller (just to be sure...)
  - Reset rest of the variables used on the view