### PR TITLE
Stabilize functional tests and HBase migration script

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -73,12 +73,16 @@ unit_tests:
 functional_tests:
 	docker-compose -f $(FUNCTIONAL_TESTS_DOCKER_COMPOSE) up -d hbase postgres rabbitmq
 	. $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && ./$(SCRIPTS_DIRECTORY)/wait_for_dependencies.sh
+	. $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && alembic upgrade head
+	. $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && $(PYTHON) ./$(SCRIPTS_DIRECTORY)/migrate_hbase.py -y
 	@if . $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && ! pytest $(FUNCTIONAL_TEST) ; then\
-		echo "Functional tests failed!";\
 		docker-compose -f $(FUNCTIONAL_TESTS_DOCKER_COMPOSE) down;\
+		echo "Functional tests failed!";\
 		exit 1;\
 	fi
+	. $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && alembic downgrade base
 	docker-compose -f $(FUNCTIONAL_TESTS_DOCKER_COMPOSE) down
+	echo "Functional tests passed!"
 
 functional_tests_docker:
 	./$(SCRIPTS_DIRECTORY)/wait_for_dependencies.sh

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -86,6 +86,8 @@ functional_tests:
 
 functional_tests_docker:
 	./$(SCRIPTS_DIRECTORY)/wait_for_dependencies.sh
+	alembic upgrade head
+	$(PYTHON) ./$(SCRIPTS_DIRECTORY)/migrate_hbase.py -y
 	pytest $(FUNCTIONAL_TESTS_MODULE)
 
 #

--- a/backend/medtagger/clients/hbase_client.py
+++ b/backend/medtagger/clients/hbase_client.py
@@ -114,6 +114,21 @@ class HBaseClient(object):
     @staticmethod
     @retry(stop_max_attempt_number=3, wait_random_min=200, wait_random_max=1000,
            retry_on_exception=lambda ex: isinstance(ex, (TTransportException, BrokenPipeError)))
+    def delete(table_name: str, key: str, columns: List[str] = None) -> None:
+        """Delete a single row (or values from colums in given row) in HBase table.
+
+        :param table_name: name of a table
+        :param key: key representing a row
+        :param columns: columns which should be cleared
+        """
+        hbase_key = str.encode(key)
+        with HBASE_CONNECTION_POOL.connection() as connection:
+            table = connection.table(table_name)
+            table.delete(hbase_key, columns=columns)
+
+    @staticmethod
+    @retry(stop_max_attempt_number=3, wait_random_min=200, wait_random_max=1000,
+           retry_on_exception=lambda ex: isinstance(ex, (TTransportException, BrokenPipeError)))
     def put(table_name: str, key: str, value: Any) -> None:
         """Add new entry into HBase table.
 


### PR DESCRIPTION
Fixes #25, #29

## Proposed Changes

  - Use Alembic and HBase migrations to setup databases for functional tests,
  - Add retrying on creating connection to HBase in migration script,
  - Do not drop and create database before and after each functional test.