### PR TITLE
Slider on labeling page cannot be moved by mouse dragging

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "LungTagger",
-  "version": "0.0.1",
+  "name": "MedTagger",
+  "version": "0.1.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -25,6 +25,7 @@
     "@angular/router": "^4.0.0",
     "@ng-bootstrap/ng-bootstrap": "^1.0.0-beta.3",
     "core-js": "^2.4.1",
+    "hammerjs": "^2.0.8",
     "ng-socket-io": "^0.1.11",
     "rxjs": "^5.4.1",
     "zone.js": "^0.8.14"

--- a/frontend/src/app/components/marker/marker.component.html
+++ b/frontend/src/app/components/marker/marker.component.html
@@ -2,6 +2,7 @@
     <img #image id="markerBackgroundImage" width="600" height="600"/>
     <canvas #canvas id="markerCanvas" width="600" height="600"></canvas>
     <mat-slider #slider id="markerSlider"
+                (blur)="this.sliderFocus()"
                 [disabled]="false"
                 [max]="10"
                 [min]="0"
@@ -11,5 +12,10 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
+    <div id="markerKeysTooltip">
+        <span matTooltip="Use arrow keys to navigate between slices" #tooltip="matTooltip">
+            <mat-icon>open_with</mat-icon>
+        </span>
+    </div>
 </div>
 

--- a/frontend/src/app/components/marker/marker.component.scss
+++ b/frontend/src/app/components/marker/marker.component.scss
@@ -26,3 +26,25 @@ $canvas-size: 600px;
     top: $canvas-size;
 }
 
+#markerKeysTooltip {
+    position: absolute;
+    left: $canvas-size + 12;
+    top: $canvas-size + 10;
+}
+
+// pretty neat workaround to always show slider thumb
+::ng-deep {
+    .mat-slider-thumb-label {
+        transform: rotate(-45deg) !important;
+        border-radius: 50% 50% 0 !important;
+    }
+
+    .mat-slider-thumb {
+        transform: scale(0) !important;
+    }
+
+    .mat-slider-thumb-label-text {
+        opacity: 1 !important;
+    }
+}
+

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -1,9 +1,10 @@
-import {Component, ElementRef, OnInit, ViewChild, HostListener} from '@angular/core';
+import {Component, ElementRef, OnInit, ViewChild, HostListener, Renderer2} from '@angular/core';
 import {MarkerSlice} from '../../model/MarkerSlice';
 import {MatSlider} from '@angular/material/slider';
 import {Subject} from 'rxjs/Subject';
 import {ScanViewerComponent} from '../scan-viewer/scan-viewer.component';
 import {SliceSelection} from '../../model/SliceSelection';
+import {MatTooltip} from "@angular/material";
 
 @Component({
     selector: 'app-marker-component',
@@ -27,6 +28,8 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
     }
 
     @ViewChild('slider') slider: MatSlider;
+
+    @ViewChild('tooltip') tooltip: MatTooltip;
 
     public has3dSelection: boolean;
     public has2dSelection: boolean;
@@ -71,7 +74,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     ngOnInit() {
         console.log('Marker init');
-        console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider);
+        console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider, ' tooltip ', this.tooltip);
 
         this.slices = new Map<number, MarkerSlice>();
 
@@ -89,10 +92,9 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
             console.log('Marker init | slider change: ', sliderValue);
 
             this.requestSlicesIfNeeded(sliderValue);
-
             this.changeMarkerImage(sliderValue);
-            this.selector.drawPreviousSelections();
 
+            this.selector.drawPreviousSelections();
             this.updateSelectionState();
         });
     }

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.html
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.html
@@ -2,6 +2,7 @@
     <img #image id="markerBackgroundImage" width="600" height="600"/>
     <canvas #canvas id="markerCanvas" width="600" height="600"></canvas>
     <mat-slider #slider id="markerSlider"
+                (blur)="this.sliderFocus()"
                 [disabled]="false"
                 [max]="10"
                 [min]="0"
@@ -11,5 +12,10 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
+    <div id="markerKeysTooltip">
+        <span matTooltip="Use arrow keys to navigate between slices" #tooltip="matTooltip">
+            <mat-icon>open_with</mat-icon>
+        </span>
+    </div>
 </div>
 

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.scss
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.scss
@@ -26,3 +26,25 @@ $canvas-size: 600px;
     top: $canvas-size;
 }
 
+#markerKeysTooltip {
+    position: absolute;
+    left: $canvas-size + 12;
+    top: $canvas-size + 10;
+}
+
+// pretty neat workaround to always show slider thumb
+::ng-deep {
+    .mat-slider-thumb-label {
+        transform: rotate(-45deg) !important;
+        border-radius: 50% 50% 0 !important;
+    }
+
+    .mat-slider-thumb {
+        transform: scale(0) !important;
+    }
+
+    .mat-slider-thumb-label-text {
+        opacity: 1 !important;
+    }
+}
+

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
@@ -2,7 +2,7 @@ import {Component, HostListener, OnInit, ViewChild, ElementRef} from '@angular/c
 import {MarkerSlice} from '../../model/MarkerSlice';
 import {Subject} from 'rxjs/Subject';
 import {ScanMetadata} from '../../model/ScanMetadata';
-import {MatSlider} from '@angular/material';
+import {MatSlider, MatTooltip} from '@angular/material';
 import {Selector} from '../selectors/Selector';
 import {SliceSelection} from '../../model/SliceSelection';
 
@@ -29,6 +29,8 @@ export class ScanViewerComponent implements OnInit {
 
     @ViewChild('slider') slider: MatSlider;
 
+    @ViewChild('tooltip') tooltip: MatTooltip;
+
     public scanMetadata: ScanMetadata;
     public slices: Map<number, MarkerSlice>;
     protected _currentSlice;
@@ -41,6 +43,15 @@ export class ScanViewerComponent implements OnInit {
     protected selector: Selector<SliceSelection>;
 
     constructor() {
+    }
+
+    ngAfterViewInit() {
+        console.log('Marker after init');
+        this.slider._elementRef.nativeElement.focus();
+    }
+
+    public sliderFocus() {
+        this.slider._elementRef.nativeElement.focus();
     }
 
     public setSelector(newSelector: Selector<SliceSelection>) {
@@ -106,6 +117,10 @@ export class ScanViewerComponent implements OnInit {
         });
     }
 
+    ngAfterViewChecked() {
+        this.tooltip.show();
+    }
+
     ngOnInit() {
         console.log('Marker init');
         console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider);
@@ -118,6 +133,7 @@ export class ScanViewerComponent implements OnInit {
 
         this.slider.registerOnChange((sliderValue: number) => {
             console.log('Marker init | slider change: ', sliderValue);
+
             this.selector.updateCurrentSlice(sliderValue);
 
             this.requestSlicesIfNeeded(sliderValue);

--- a/frontend/src/app/main/app.module.ts
+++ b/frontend/src/app/main/app.module.ts
@@ -38,7 +38,8 @@ import {
     MatExpansionModule,
     MatSnackBarModule,
     MatSelectModule,
-    MatTooltipModule, MatDialog, MatDialogModule,
+    MatTooltipModule,
+    MatDialog, MatDialogModule, MatIconRegistry,
 } from '@angular/material';
 import {ScanViewerComponent} from '../components/scan-viewer/scan-viewer.component';
 import {AuthenticationHeader} from '../services/authentication-header';
@@ -66,6 +67,7 @@ import {InfoDialog} from "../dialogs/info.dialog";
     ],
     imports: [
         routing,
+        BrowserModule,
         MatToolbarModule,
         MatCardModule,
         MatProgressBarModule,
@@ -82,8 +84,6 @@ import {InfoDialog} from "../dialogs/info.dialog";
         MatGridListModule,
         MatTooltipModule,
         MatDialogModule,
-        BrowserModule,
-        BrowserAnimationsModule,
         BrowserAnimationsModule,
         FormsModule,
         ReactiveFormsModule,
@@ -106,5 +106,4 @@ import {InfoDialog} from "../dialogs/info.dialog";
     ],
     bootstrap: [AppComponent]
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/frontend/src/app/pages/marker-page/marker-page.component.scss
+++ b/frontend/src/app/pages/marker-page/marker-page.component.scss
@@ -19,3 +19,4 @@ button {
 .button-row {
     text-align: center;
 }
+

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -59,6 +59,8 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * APPLICATION IMPORTS
  */
 
+import 'hammerjs';
+
 /**
  * Date, currency, decimal and percent pipes.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10


### PR DESCRIPTION
Fixes `Slider on labeling page cannot be moved by mouse dragging` #95

## Proposed Changes

  - Slide focus on validation/marker page
  - Slider thumb showing all the time by css magic
  - Slide effect when dragging thumb on slider (added `hammer.js` dependency)
  - Tooltip with icon to remind user of keyboard navigation functionality
  - Changed legacy project name in `package.json`
  - Tested on Firefox/Chrome/Opera/Vivaldi
