### PR TITLE
Allow to send "no info" selections and 2D ones. Send tag immediately after selection.

### DIFF
--- a/frontend/src/app/components/marker/marker.component.html
+++ b/frontend/src/app/components/marker/marker.component.html
@@ -12,10 +12,5 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
-    <div id="markerKeysTooltip">
-        <span matTooltip="Use arrow keys to navigate between slices" #tooltip="matTooltip">
-            <mat-icon>open_with</mat-icon>
-        </span>
-    </div>
 </div>
 

--- a/frontend/src/app/components/marker/marker.component.scss
+++ b/frontend/src/app/components/marker/marker.component.scss
@@ -26,12 +26,6 @@ $canvas-size: 600px;
     top: $canvas-size;
 }
 
-#markerKeysTooltip {
-    position: absolute;
-    left: $canvas-size + 12;
-    top: $canvas-size + 10;
-}
-
 // pretty neat workaround to always show slider thumb
 ::ng-deep {
     .mat-slider-thumb-label {

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, OnInit, ViewChild, HostListener, Renderer2} from '@angular/core';
+import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
 import {MarkerSlice} from '../../model/MarkerSlice';
 import {MatSlider} from '@angular/material/slider';
 import {Subject} from 'rxjs/Subject';
@@ -31,9 +31,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     @ViewChild('tooltip') tooltip: MatTooltip;
 
-    public has3dSelection: boolean;
-    public has2dSelection: boolean;
-    public hasArchivedSelections: boolean;
+    public selectionState: {isValid: boolean, is2d: boolean, hasArchive: boolean} = { isValid: false, is2d: false, hasArchive: false};
 
     public observableSliceRequest: Subject<number>;
 
@@ -51,13 +49,12 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
     }
 
     private updateSelectionState(): void {
-        this.hasArchivedSelections = this.selector.hasArchivedSelections();
-        this.has2dSelection = this.selector.hasSliceSelection();
-        this.has3dSelection = this.selector.hasFullSelection();
+        this.selectionState.hasArchive = this.selector.hasArchivedSelections();
+        this.selectionState.is2d = this.selector.hasSliceSelection();
+        this.selectionState.isValid = this.selector.hasValidSelection();
     }
 
     public get3dSelection(): SliceSelection[] {
-        this.selector.addCurrentSelection();
         this.selector.archiveSelections();
         this.updateSelectionState();
 
@@ -80,6 +77,10 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
         this.selector.clearData();
 
+        this.selector.getStateChangeEmitter().subscribe(()=> {
+            this.updateSelectionState();
+        });
+
         this.initializeCanvas();
 
         this.currentImage.onload = () => {
@@ -97,6 +98,8 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
             this.selector.drawPreviousSelections();
             this.updateSelectionState();
         });
+
+
     }
 
     private initCanvasSelectionTool(): void {

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -29,8 +29,6 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     @ViewChild('slider') slider: MatSlider;
 
-    @ViewChild('tooltip') tooltip: MatTooltip;
-
     public selectionState: {isValid: boolean, is2d: boolean, hasArchive: boolean} = { isValid: false, is2d: false, hasArchive: false};
 
     public observableSliceRequest: Subject<number>;
@@ -71,7 +69,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     ngOnInit() {
         console.log('Marker init');
-        console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider, ' tooltip ', this.tooltip);
+        console.log('View elements: image ', this.currentImage, ', canvas ', this.canvas, ', slider ', this.slider);
 
         this.slices = new Map<number, MarkerSlice>();
 

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.html
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.html
@@ -12,10 +12,5 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
-    <div id="markerKeysTooltip">
-        <span matTooltip="Use arrow keys to navigate between slices" #tooltip="matTooltip">
-            <mat-icon>open_with</mat-icon>
-        </span>
-    </div>
 </div>
 

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.scss
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.scss
@@ -26,12 +26,6 @@ $canvas-size: 600px;
     top: $canvas-size;
 }
 
-#markerKeysTooltip {
-    position: absolute;
-    left: $canvas-size + 12;
-    top: $canvas-size + 10;
-}
-
 // pretty neat workaround to always show slider thumb
 ::ng-deep {
     .mat-slider-thumb-label {

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
@@ -2,7 +2,7 @@ import {Component, HostListener, OnInit, ViewChild, ElementRef} from '@angular/c
 import {MarkerSlice} from '../../model/MarkerSlice';
 import {Subject} from 'rxjs/Subject';
 import {ScanMetadata} from '../../model/ScanMetadata';
-import {MatSlider, MatTooltip} from '@angular/material';
+import {MatSlider} from '@angular/material';
 import {Selector} from '../selectors/Selector';
 import {SliceSelection} from '../../model/SliceSelection';
 import {Subscriber} from "rxjs/Subscriber";
@@ -29,8 +29,6 @@ export class ScanViewerComponent implements OnInit {
     }
 
     @ViewChild('slider') slider: MatSlider;
-
-    @ViewChild('tooltip') tooltip: MatTooltip;
 
     public scanMetadata: ScanMetadata;
     public slices: Map<number, MarkerSlice>;
@@ -116,12 +114,7 @@ export class ScanViewerComponent implements OnInit {
         });
     }
 
-    ngAfterViewChecked() {
-        // Waiting for next rendering cycle to avoid race conditions
-        setTimeout(()=> {
-            this.tooltip.show();
-        }, 0);
-    }
+    ngAfterViewChecked() {}
 
     ngOnInit() {
         console.log('ScanViewer | ngOnInit');

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
@@ -5,6 +5,7 @@ import {ScanMetadata} from '../../model/ScanMetadata';
 import {MatSlider, MatTooltip} from '@angular/material';
 import {Selector} from '../selectors/Selector';
 import {SliceSelection} from '../../model/SliceSelection';
+import {Subscriber} from "rxjs/Subscriber";
 
 @Component({
     selector: 'app-scan-viewer',
@@ -34,8 +35,6 @@ export class ScanViewerComponent implements OnInit {
     public scanMetadata: ScanMetadata;
     public slices: Map<number, MarkerSlice>;
     protected _currentSlice;
-
-    public hasArchivedSelections: boolean;
 
     public observableSliceRequest: Subject<number>;
     protected sliceBatchSize: number;

--- a/frontend/src/app/components/selectors/Selector.ts
+++ b/frontend/src/app/components/selectors/Selector.ts
@@ -1,4 +1,4 @@
-import {SliceSelection} from '../../model/SliceSelection';
+import {EventEmitter} from "@angular/core";
 
 export interface Selector<SliceSelection> {
 
@@ -16,6 +16,8 @@ export interface Selector<SliceSelection> {
 
     clearData(): any;
 
+    getStateChangeEmitter(): EventEmitter<void>;
+
     addCurrentSelection(): any;
 
     updateCurrentSlice(currentSliceId: number): any;
@@ -26,7 +28,7 @@ export interface Selector<SliceSelection> {
 
     hasSliceSelection(): boolean;
 
-    hasFullSelection(): boolean;
+    hasValidSelection(...validityFlags: boolean[]): boolean;
 
     getSelections(): SliceSelection[];
 

--- a/frontend/src/app/model/ROISelection2D.ts
+++ b/frontend/src/app/model/ROISelection2D.ts
@@ -44,7 +44,10 @@ export class ROISelection2D implements SliceSelection {
         this._height = newHeight;
     }
 
-    public toJSON(scalar: number): SelectionData {
+    public toJSON(): SelectionData {
+        // TODO: Avoid using scalar or provide it by some static context
+        const scalar = 600;
+
         let correctPositionX = this._positionX;
         let correctPositionY = this._positionY;
         let correctWidth = this._width;

--- a/frontend/src/app/model/ROISelection3D.ts
+++ b/frontend/src/app/model/ROISelection3D.ts
@@ -5,7 +5,7 @@ import {ScanSelection} from './ScanSelection';
 export class ROISelection3D implements ScanSelection<ROISelection2D> {
     _selections: ROISelection2D[];
 
-    constructor(selections: ROISelection2D[]) {
+    constructor(selections?: ROISelection2D[]) {
         this._selections = selections;
     }
 
@@ -17,14 +17,14 @@ export class ROISelection3D implements ScanSelection<ROISelection2D> {
         return coordinatesArray;
     }
 
-    public toJSON(): { selections: SelectionData[] } {
-        // TODO: w jakiś elegancki sposób wyciągnięcie tego z widoku
-        const canvasSize = 600;
-        const jsonObject: { selections: SelectionData[] } = { selections: undefined };
+    toJSON(): Object {
+        let jsonObject: { selections: SelectionData[] } = {selections: undefined};
         jsonObject.selections = [];
-        this._selections.forEach((selection: ROISelection2D) => {
-            jsonObject.selections.push(selection.toJSON(canvasSize));
-        });
+        if (this._selections) {
+            this._selections.forEach((selection: ROISelection2D) => {
+                jsonObject.selections.push(selection.toJSON());
+            });
+        }
 
         return jsonObject;
     }

--- a/frontend/src/app/model/ScanSelection.ts
+++ b/frontend/src/app/model/ScanSelection.ts
@@ -1,5 +1,5 @@
 export interface ScanSelection<SliceSelection> {
     _selections: SliceSelection[];
 
-    toJSON(scalar: number): Object;
+    toJSON(): Object;
 }

--- a/frontend/src/app/model/SelectionData.ts
+++ b/frontend/src/app/model/SelectionData.ts
@@ -1,4 +1,4 @@
-export class SelectionData {
+export class SelectionData extends Object {
     slice_index: number;
     x: number;
     y: number;
@@ -6,6 +6,7 @@ export class SelectionData {
     height: number;
 
     constructor(index: number, x: number, y: number, width: number, height: number) {
+        super();
         this.slice_index = index;
         this.x = x;
         this.y = y;

--- a/frontend/src/app/pages/marker-page/marker-page.component.html
+++ b/frontend/src/app/pages/marker-page/marker-page.component.html
@@ -1,18 +1,21 @@
 <div class="marker-page">
     <div class="innerElement canvasInterface">
-        <app-marker-component #marker></app-marker-component>
+        <app-marker-component #marker (selectionStateNotification)="updateSelectionState()"></app-marker-component>
         <div class="button-row">
-            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="!this.marker.hasArchivedSelections">
+            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="!this.marker.selectionState.hasArchive">
                 Skip scan
             </button>
-            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="this.marker.hasArchivedSelections">
+            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="this.marker.selectionState.hasArchive">
                 Next scan
             </button>
-            <button mat-raised-button color="warn" [disabled]="!this.marker.has2dSelection"
+            <button mat-raised-button color="warn" [disabled]="!this.marker.selectionState.is2d"
                     (click)="remove2dSelection()">Delete current label
             </button>
-            <button mat-raised-button color="accent" [disabled]="!this.marker.has3dSelection" (click)="sendSelection()">
+            <button mat-raised-button color="accent" [disabled]="!this.marker.selectionState.isValid" (click)="sendCompleteLabel()">
                 Send label
+            </button>
+            <button mat-raised-button color="accent" (click)="sendEmptyLabel()">
+                Nothing to tag
             </button>
         </div>
     </div>

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -71,6 +71,10 @@ export class MarkerPageComponent implements OnInit {
         });
     }
 
+    public updateSelectionState() {
+
+    }
+
     private requestScan(): void {
         this.scanService.getRandomScan(this.category).then(
             (scan: ScanMetadata) => {
@@ -98,10 +102,19 @@ export class MarkerPageComponent implements OnInit {
         this.requestScan();
     }
 
-    public sendSelection() {
+    public sendCompleteLabel(): void {
+        this.sendSelection(new ROISelection3D(<ROISelection2D[]>this.marker.get3dSelection()));
+    }
+
+    public sendEmptyLabel(): void {
+        this.sendSelection(new ROISelection3D());
+        this.skipScan();
+    }
+
+    private sendSelection(roiSelection: ROISelection3D) {
         const labelingTime = this.getLabelingTimeInSeconds(this.startTime);
-        const roiSelection: ROISelection3D = new ROISelection3D(<ROISelection2D[]>this.marker.get3dSelection());
-        this.scanService.send3dSelection(this.scan.scanId, roiSelection, labelingTime)
+
+        this.scanService.sendSelection(this.scan.scanId, roiSelection, labelingTime)
             .then((response: Response) => {
                 if (response.status === 200) {
                     console.log('MarkerPage | sendSelection | success!');

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -7,9 +7,10 @@ import 'rxjs/add/operator/toPromise';
 import {Observable} from 'rxjs/Observable';
 import {ScanCategory, ScanMetadata} from '../model/ScanMetadata';
 import {MarkerSlice} from '../model/MarkerSlice';
-import {ROISelection3D} from '../model/ROISelection3D';
 
 import {environment} from '../../environments/environment';
+import {ScanSelection} from "../model/ScanSelection";
+import {SliceSelection} from "../model/SliceSelection";
 
 
 @Injectable()
@@ -21,9 +22,9 @@ export class ScanService {
         this.websocket = new Socket({url: environment.WEBSOCKET_URL + '/slices', options: {}});
     }
 
-    public send3dSelection(scanId: string, roiSelection: ROISelection3D, labelingTime: number): Promise<Response> {
-        console.log('ScanService | send3dSelection | sending ROI:', roiSelection, `for scanId: ${scanId}`, `with labeling time: ${labelingTime}`);
-        const payload = roiSelection.toJSON();
+    public sendSelection(scanId: string, selection: ScanSelection<SliceSelection>, labelingTime: number): Promise<Response> {
+        console.log('ScanService | send3dSelection | sending ROI:', selection, `for scanId: ${scanId}`, `with labeling time: ${labelingTime}`);
+        const payload = selection.toJSON();
         payload['labeling_time'] = labelingTime;
         return new Promise((resolve, reject) => {
             this.http.post(environment.API_URL + `/scans/${scanId}/label`, payload).toPromise().then((response: Response) => {


### PR DESCRIPTION
## Proposed Changes

  - New rules for enabling "Send selection" button
  - Fix: A need to move slider, to enable sending last/one selection (new communication between selector and marker classes)
  - Fix: Graphical glitches and bugs from tooltip directive (removed tooltip from validation/labelling pages)
  - New way to send info about lack of interesting things on scan ("Nothing to tag" button)
  - Few cleanups