### PR TITLE
Added spinner and snackbar to indicate loading on marker page

### DIFF
--- a/frontend/src/app/components/marker/marker.component.html
+++ b/frontend/src/app/components/marker/marker.component.html
@@ -12,5 +12,8 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
+    <div *ngIf="downloadingScanInProgress">
+         <mat-progress-spinner id="markerSpinner" mode="indeterminate" color="accent"></mat-progress-spinner>
+    </div>
 </div>
 

--- a/frontend/src/app/components/marker/marker.component.html
+++ b/frontend/src/app/components/marker/marker.component.html
@@ -12,7 +12,7 @@
                 [value]="this.currentSlice"
                 [vertical]="true">
     </mat-slider>
-    <div *ngIf="downloadingScanInProgress">
+    <div *ngIf="downloadingScanInProgress || downloadingSlicesInProgress">
          <mat-progress-spinner id="markerSpinner" mode="indeterminate" color="accent"></mat-progress-spinner>
     </div>
 </div>

--- a/frontend/src/app/components/marker/marker.component.scss
+++ b/frontend/src/app/components/marker/marker.component.scss
@@ -2,6 +2,7 @@
 
 $canvas-size: 600px;
 $slider-offset: 20px;
+$spinner-radius: 50px;
 
 #markerCanvas {
     width: $canvas-size;
@@ -13,6 +14,12 @@ $slider-offset: 20px;
 #markerBackgroundImage {
     @extend #markerCanvas;
     background-color: grey;
+}
+
+#markerSpinner {
+    @extend #markerCanvas;
+    left: $canvas-size / 3 + $spinner-radius;
+    top: $canvas-size / 3 + $spinner-radius;
 }
 
 #markerSlider {

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -14,6 +14,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     currentImage: HTMLImageElement;
     downloadingScanInProgress = false;
+    downloadingSlicesInProgress = false;
 
     @ViewChild('image')
     set viewImage(viewElement: ElementRef) {
@@ -68,7 +69,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
     }
 
     private hookUpStateChangeSubscription(): void {
-        this.selector.getStateChangeEmitter().subscribe(()=> {
+        this.selector.getStateChangeEmitter().subscribe(() => {
             console.log('Marker | getStateChange event from selector!');
             this.updateSelectionState();
         });

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -4,7 +4,6 @@ import {MatSlider} from '@angular/material/slider';
 import {Subject} from 'rxjs/Subject';
 import {ScanViewerComponent} from '../scan-viewer/scan-viewer.component';
 import {SliceSelection} from '../../model/SliceSelection';
-import {MatTooltip} from "@angular/material";
 
 @Component({
     selector: 'app-marker-component',

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -13,6 +13,7 @@ import {SliceSelection} from '../../model/SliceSelection';
 export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     currentImage: HTMLImageElement;
+    downloadingScanInProgress = false;
 
     @ViewChild('image')
     set viewImage(viewElement: ElementRef) {

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -42,6 +42,14 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
         return this._currentSlice;
     }
 
+    public setDownloadScanInProgress(isInProgress: boolean) {
+        this.downloadingScanInProgress = isInProgress;
+    }
+
+    public setDownloadSlicesInProgress(isInProgress: boolean) {
+        this.downloadingSlicesInProgress = isInProgress;
+    }
+
     public removeCurrentSelection(): void {
         this.selector.removeCurrentSelection();
         this.updateSelectionState();

--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
@@ -5,7 +5,6 @@ import {ScanMetadata} from '../../model/ScanMetadata';
 import {MatSlider} from '@angular/material';
 import {Selector} from '../selectors/Selector';
 import {SliceSelection} from '../../model/SliceSelection';
-import {Subscriber} from "rxjs/Subscriber";
 
 @Component({
     selector: 'app-scan-viewer',
@@ -130,7 +129,6 @@ export class ScanViewerComponent implements OnInit {
             console.log('ScanViewer init | slider change: ', sliderValue);
 
             this.selector.updateCurrentSlice(sliderValue);
-
             this.requestSlicesIfNeeded(sliderValue);
 
             this.changeMarkerImage(sliderValue);

--- a/frontend/src/app/pages/marker-page/marker-page.component.html
+++ b/frontend/src/app/pages/marker-page/marker-page.component.html
@@ -2,10 +2,10 @@
     <div class="innerElement canvasInterface">
         <app-marker-component #marker></app-marker-component>
         <div class="button-row">
-            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="!this.marker.selectionState.hasArchive">
+            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="!this.marker.selectionState.hasArchive" [disabled]="this.marker.downloadingScanInProgress">
                 Skip scan
             </button>
-            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="this.marker.selectionState.hasArchive">
+            <button mat-raised-button color="primary" (click)="skipScan()" *ngIf="this.marker.selectionState.hasArchive" [disabled]="this.marker.downloadingScanInProgress">
                 Next scan
             </button>
             <button mat-raised-button color="warn" [disabled]="!this.marker.selectionState.is2d"
@@ -14,7 +14,7 @@
             <button mat-raised-button color="accent" [disabled]="!this.marker.selectionState.isValid" (click)="sendCompleteLabel()">
                 Send label
             </button>
-            <button mat-raised-button color="accent" [disabled]="this.marker.selectionState.hasArchive || this.marker.selectionState.isValid" (click)="sendEmptyLabel()">
+            <button mat-raised-button color="accent" [disabled]="this.marker.selectionState.hasArchive || this.marker.selectionState.isValid || this.marker.downloadingScanInProgress" (click)="sendEmptyLabel()">
                 Nothing to tag
             </button>
         </div>

--- a/frontend/src/app/pages/marker-page/marker-page.component.html
+++ b/frontend/src/app/pages/marker-page/marker-page.component.html
@@ -18,5 +18,8 @@
                 Nothing to tag
             </button>
         </div>
+        <div *ngIf="downloadingScanInProgress">
+            <mat-progress-spinner class="scanSpinner" mode="indeterminate" color="accent"></mat-progress-spinner>
+        </div>
     </div>
 </div>

--- a/frontend/src/app/pages/marker-page/marker-page.component.html
+++ b/frontend/src/app/pages/marker-page/marker-page.component.html
@@ -18,8 +18,5 @@
                 Nothing to tag
             </button>
         </div>
-        <div *ngIf="downloadingScanInProgress">
-            <mat-progress-spinner class="scanSpinner" mode="indeterminate" color="accent"></mat-progress-spinner>
-        </div>
     </div>
 </div>

--- a/frontend/src/app/pages/marker-page/marker-page.component.scss
+++ b/frontend/src/app/pages/marker-page/marker-page.component.scss
@@ -19,7 +19,3 @@ button {
 .button-row {
     text-align: center;
 }
-
-.scanSpinner {
-  margin: 200px auto 0;
-}

--- a/frontend/src/app/pages/marker-page/marker-page.component.scss
+++ b/frontend/src/app/pages/marker-page/marker-page.component.scss
@@ -20,3 +20,6 @@ button {
     text-align: center;
 }
 
+.scanSpinner {
+  margin: 200px auto 0;
+}

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -53,6 +53,7 @@ export class MarkerPageComponent implements OnInit {
                 this.lastSliceID = slice.index;
             }
             this.marker.feedData(slice);
+            this.marker.downloadingSlicesInProgress = false;
             this.marker.downloadingScanInProgress = false;
             this.indicateNewScanAppeared();
         });
@@ -69,6 +70,7 @@ export class MarkerPageComponent implements OnInit {
                         count = count + sliceRequest;
                         sliceRequest = 0;
                     }
+                    this.marker.downloadingSlicesInProgress = true;
                     this.scanService.requestSlices(this.scan.scanId, sliceRequest, count);
                 });
             }
@@ -90,6 +92,7 @@ export class MarkerPageComponent implements OnInit {
             },
             (errorResponse: Error) => {
                 console.log(errorResponse);
+                this.marker.downloadingScanInProgress = false;
                 this.dialogService
                     .openInfoDialog('Nothing to do here!', 'No more Scans available for you in this category!', 'Go back')
                     .afterClosed()

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -30,7 +30,6 @@ export class MarkerPageComponent implements OnInit {
     category: string;
     lastSliceID = 0;
     startTime: Date;
-    downloadingScanInProgress = false;
 
     constructor(private scanService: ScanService, private route: ActivatedRoute, private dialogService: DialogService,
                 private location: Location, private snackBar: MatSnackBar) {
@@ -39,7 +38,7 @@ export class MarkerPageComponent implements OnInit {
 
     ngOnInit() {
         console.log('MarkerPage init', this.marker);
-        this.downloadingScanInProgress = true;
+        this.marker.downloadingScanInProgress = true;
 
         this.marker.setSelector(new RectROISelector(this.marker.getCanvas()));
 
@@ -53,13 +52,9 @@ export class MarkerPageComponent implements OnInit {
             if (slice.index > this.lastSliceID) {
                 this.lastSliceID = slice.index;
             }
-            new Promise((resolve => {
-                this.marker.feedData(slice);
-                resolve();
-            })).then(() => {
-                this.downloadingScanInProgress = false;
-                this.indicateNewScanAppeared();
-          });
+            this.marker.feedData(slice);
+            this.marker.downloadingScanInProgress = false;
+            this.indicateNewScanAppeared();
         });
 
         this.marker.hookUpSliceObserver(MarkerPageComponent.SLICE_BATCH_SIZE).then((isObserverHooked: boolean) => {
@@ -81,7 +76,7 @@ export class MarkerPageComponent implements OnInit {
     }
 
     private requestScan(): void {
-      this.downloadingScanInProgress = true;
+      this.marker.downloadingScanInProgress = true;
         this.scanService.getRandomScan(this.category).then(
             (scan: ScanMetadata) => {
                 this.scan = scan;
@@ -91,7 +86,7 @@ export class MarkerPageComponent implements OnInit {
                 const count = MarkerPageComponent.SLICE_BATCH_SIZE;
                 this.startMeasuringLabelingTime();
                 this.scanService.requestSlices(scan.scanId, begin, count);
-                this.downloadingScanInProgress = false;
+                this.marker.downloadingScanInProgress = false;
             },
             (errorResponse: Error) => {
                 console.log(errorResponse);
@@ -105,7 +100,7 @@ export class MarkerPageComponent implements OnInit {
     }
 
     public skipScan(): void {
-        this.downloadingScanInProgress = true;
+        this.marker.downloadingScanInProgress = true;
         this.marker.prepareForNewScan();
         this.requestScan();
     }
@@ -150,6 +145,6 @@ export class MarkerPageComponent implements OnInit {
     }
 
     private indicateNewScanAppeared(): void {
-      this.snackBar.open('New scan has been loaded!', ' ', {duration: 2000,});
+      this.snackBar.open('New scan has been loaded', '', {duration: 2000,});
     }
 }

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -62,15 +62,17 @@ export class MarkerPageComponent implements OnInit {
             if (isObserverHooked) {
                 this.marker.observableSliceRequest.subscribe((sliceRequest: number) => {
                     console.log('MarkerPage | observable sliceRequest: ', sliceRequest);
+                    this.marker.downloadingSlicesInProgress = true;
                     let count = MarkerPageComponent.SLICE_BATCH_SIZE;
                     if (sliceRequest + count > this.scan.numberOfSlices) {
                         count = this.scan.numberOfSlices - sliceRequest;
+                        this.marker.downloadingSlicesInProgress = false;
                     }
                     if (sliceRequest < 0) {
                         count = count + sliceRequest;
                         sliceRequest = 0;
+                        this.marker.downloadingSlicesInProgress = false;
                     }
-                    this.marker.downloadingSlicesInProgress = true;
                     this.scanService.requestSlices(this.scan.scanId, sliceRequest, count);
                 });
             }
@@ -93,6 +95,7 @@ export class MarkerPageComponent implements OnInit {
             (errorResponse: Error) => {
                 console.log(errorResponse);
                 this.marker.downloadingScanInProgress = false;
+                this.marker.downloadingSlicesInProgress = false;
                 this.dialogService
                     .openInfoDialog('Nothing to do here!', 'No more Scans available for you in this category!', 'Go back')
                     .afterClosed()
@@ -131,6 +134,7 @@ export class MarkerPageComponent implements OnInit {
                     .openInfoDialog('Error', 'Cannot send selection', 'Ok');
             });
         this.startMeasuringLabelingTime();
+        this.indicateLabelHasBeenSend();
         return;
     }
 
@@ -147,7 +151,11 @@ export class MarkerPageComponent implements OnInit {
       return (endTime.getTime() - startTime.getTime()) / 1000.0;
     }
 
+    private indicateLabelHasBeenSend(): void {
+      this.snackBar.open('Label has been send', '', {duration: 2000, });
+    }
+
     private indicateNewScanAppeared(): void {
-      this.snackBar.open('New scan has been loaded', '', {duration: 2000,});
+      this.snackBar.open('New scan has been loaded', '', {duration: 2000, });
     }
 }

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -22,6 +22,7 @@ import {Location} from '@angular/common';
 export class MarkerPageComponent implements OnInit {
 
     private static readonly SLICE_BATCH_SIZE = 10;
+    downloadingScanInProgress: boolean;
 
     @ViewChild(MarkerComponent) marker: MarkerComponent;
 
@@ -37,6 +38,7 @@ export class MarkerPageComponent implements OnInit {
 
     ngOnInit() {
         console.log('MarkerPage init', this.marker);
+        this.downloadingScanInProgress = true;
 
         this.marker.setSelector(new RectROISelector(this.marker.getCanvas()));
 
@@ -51,6 +53,7 @@ export class MarkerPageComponent implements OnInit {
                 this.lastSliceID = slice.index;
             }
             this.marker.feedData(slice);
+            this.downloadingScanInProgress = false;
         });
 
         this.marker.hookUpSliceObserver(MarkerPageComponent.SLICE_BATCH_SIZE).then((isObserverHooked: boolean) => {


### PR DESCRIPTION
Fixes #45, #152 and #132 

## Proposed Changes

Added a simple spinner to tell user that new scan is loaded when:
- user enters labeling page for the first time,
- when users clicks on `Nothing to tag` button,
- when user click on `Skip scan` button.

There is also a snackbar that indicates when new scan is loaded.
