### PR TITLE
Enable Traefik for easy scalability

### DIFF
--- a/backend/scripts/stress_test.js
+++ b/backend/scripts/stress_test.js
@@ -46,7 +46,6 @@ function logIn(handler) {
         }
     }, (err, res, body) => {
         console.log('Successfully logged in!');
-        console.log(body['token']);
         handler(body['token']);
     });
 }
@@ -60,8 +59,6 @@ function getRandomScan(authToken, handler) {
         },
         json: true
     }, (err, res, body) => {
-        console.log(res.statusCode);
-        console.log(body);
         console.log('Received Scan (', body['scan_id'], ') with', body['number_of_slices'], 'Slices.');
         handler(body['scan_id'], body['number_of_slices']);
     });

--- a/backend/scripts/stress_test.js
+++ b/backend/scripts/stress_test.js
@@ -4,8 +4,8 @@ const request = require('request');
 // Test definition
 const MEDTAGGER_USER = 'admin@medtagger.com';
 const MEDTAGGER_PASSWORD = 'medtagger1'
-const MEDTAGGER_INSTANCE_REST_URL = 'http://localhost:51000';
-const MEDTAGGER_INSTANCE_WEBSOCKET_URL = 'http://localhost:51001';
+const MEDTAGGER_INSTANCE_REST_URL = 'http://localhost';
+const MEDTAGGER_INSTANCE_WEBSOCKET_URL = 'http://localhost';
 const SCAN_CATEGORY = 'KIDNEYS';
 const SCAN_BEGIN = 0;
 const SCAN_COUNT = 10;
@@ -17,9 +17,24 @@ var NUMBER_OF_SLICES = 0;
 var RECEIVED_SLICES_IDS = [];
 var REQUEST_NEXT_SLICES_ON_SIZE = SCAN_COUNT;
 var BATCH_REQUEST_STARTED = Date.now();
+var socket;
 
-console.log('Connecting to the WebSocket server...');
-const socket = io(MEDTAGGER_INSTANCE_WEBSOCKET_URL + '/slices');
+
+function getCookiesForWebSocketStickness(handler) {
+    request.get({
+        url: MEDTAGGER_INSTANCE_WEBSOCKET_URL + '/socket.io/',
+    }, (err, res, body) => {
+        var cookies = res.headers['set-cookie'];
+        var webSocketNode;
+        cookies.forEach(function(cookie) {
+            if (cookie.startsWith('MEDTAGER_WEBSOCKET_NODE=')) {
+                webSocketNode = cookie.split('=')[1].split(';')[0];
+            }
+        });
+        console.log('Using Node:', webSocketNode);
+        handler('MEDTAGER_WEBSOCKET_NODE=' + webSocketNode);
+    });
+}
 
 function logIn(handler) {
     console.log('Logging in...');
@@ -31,6 +46,7 @@ function logIn(handler) {
         }
     }, (err, res, body) => {
         console.log('Successfully logged in!');
+        console.log(body['token']);
         handler(body['token']);
     });
 }
@@ -44,6 +60,8 @@ function getRandomScan(authToken, handler) {
         },
         json: true
     }, (err, res, body) => {
+        console.log(res.statusCode);
+        console.log(body);
         console.log('Received Scan (', body['scan_id'], ') with', body['number_of_slices'], 'Slices.');
         handler(body['scan_id'], body['number_of_slices']);
     });
@@ -59,40 +77,51 @@ function requestSlices(scan_id, begin, count) {
     });
 };
 
-socket.on('connect', function() {
-    console.log('Connected');
-    logIn((authToken) => {
-        AUTH_TOKEN = authToken;
-        getRandomScan(AUTH_TOKEN, (scanID, numberOfSlices) => {
-            SCAN_ID = scanID;
-            NUMBER_OF_SLICES = numberOfSlices;
-            requestSlices(SCAN_ID, SCAN_BEGIN, SCAN_COUNT);
+logIn((authToken) => {
+    AUTH_TOKEN = authToken;
+
+    getCookiesForWebSocketStickness((cookies) => {
+        console.log('Connecting to the WebSocket server...');
+        socket = io(MEDTAGGER_INSTANCE_WEBSOCKET_URL + '/slices', {
+            extraHeaders: { 'Cookie': cookies }
         });
+
+        socket.on('connect', function() {
+            console.log('Connected');
+            getRandomScan(AUTH_TOKEN, (scanID, numberOfSlices) => {
+                SCAN_ID = scanID;
+                NUMBER_OF_SLICES = numberOfSlices;
+                requestSlices(SCAN_ID, SCAN_BEGIN, SCAN_COUNT);
+            });
+        });
+
+        socket.on('slice', function(data) {
+            RECEIVED_SLICES_IDS.push(data['index']);
+            if (RECEIVED_SLICES_IDS.length == NUMBER_OF_SLICES) {
+                console.log('This is the end of Slices for this Scan. Requesting new one...');
+                RECEIVED_SLICES_IDS = [];
+                REQUEST_NEXT_SLICES_ON_SIZE = SCAN_COUNT;
+
+                getRandomScan(AUTH_TOKEN, (scanID, numberOfSlices) => {
+                    SCAN_ID = scanID;
+                    NUMBER_OF_SLICES = numberOfSlices;
+                    requestSlices(SCAN_ID, SCAN_BEGIN, SCAN_COUNT);
+                });
+                return;
+            }
+            if (RECEIVED_SLICES_IDS.length == REQUEST_NEXT_SLICES_ON_SIZE) {
+                console.log('It took', (Date.now() - BATCH_REQUEST_STARTED) / 1000, 'seconds to get this batch.');
+                REQUEST_NEXT_SLICES_ON_SIZE += SCAN_COUNT;
+                requestSlices(SCAN_ID, RECEIVED_SLICES_IDS.length, SCAN_COUNT);
+            }
+        });
+
+        socket.on('disconnect', function() {
+            console.log('Disconnected');
+        });
+
     });
+
 });
 
-socket.on('slice', function(data) {
-    RECEIVED_SLICES_IDS.push(data['index']);
-    if (RECEIVED_SLICES_IDS.length == NUMBER_OF_SLICES) {
-        console.log('This is the end of Slices for this Scan. Requesting new one...');
-        RECEIVED_SLICES_IDS = [];
-        REQUEST_NEXT_SLICES_ON_SIZE = SCAN_COUNT;
-
-        getRandomScan(AUTH_TOKEN, (scanID, numberOfSlices) => {
-            SCAN_ID = scanID;
-            NUMBER_OF_SLICES = numberOfSlices;
-            requestSlices(SCAN_ID, SCAN_BEGIN, SCAN_COUNT);
-        });
-        return;
-    }
-    if (RECEIVED_SLICES_IDS.length == REQUEST_NEXT_SLICES_ON_SIZE) {
-        console.log('It took', (Date.now() - BATCH_REQUEST_STARTED) / 1000, 'seconds to get this batch.');
-        REQUEST_NEXT_SLICES_ON_SIZE += SCAN_COUNT;
-        requestSlices(SCAN_ID, RECEIVED_SLICES_IDS.length, SCAN_COUNT);
-    }
-});
-
-socket.on('disconnect', function() {
-    console.log('Disconnected');
-});
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,15 @@ version: '3'
 services:
   reverse-proxy:
     image: traefik
-    command: --configFile=/var/traefik/traefik.toml
+    command: --debug --configFile=/var/traefik/traefik.toml
     ports:
       - 80:80
       - 7128:8080
     volumes:
       - $PWD/traefik.toml:/var/traefik/traefik.toml
       - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "traefik.enable=false"
 
   hbase:
     image: dajobe/hbase
@@ -22,6 +24,8 @@ services:
       - 9095:9095
       - 2181:2181
       - 16010:16010
+    labels:
+      - "traefik.enable=false"
 
   rabbitmq:
     image: rabbitmq:management
@@ -34,6 +38,8 @@ services:
       - 15671:15671
       - 15672:15672
       - 25672:25672
+    labels:
+      - "traefik.enable=false"
 
   postgres:
     image: postgres
@@ -45,6 +51,8 @@ services:
       POSTGRES_DB: medtagger
       POSTGRES_USER: medtagger_user
       POSTGRES_PASSWORD: MedTa99er!
+    labels:
+      - "traefik.enable=false"
 
   medtagger_frontend:
     image: medtagger_frontend/web
@@ -53,10 +61,11 @@ services:
       dockerfile: Dockerfile
       args:
         - PRODUCTION=${MEDTAGGER__FRONTEND_PRODUCTION}
-    ports:
-      - 80:80
     depends_on:
       - medtagger_backend_rest
+    labels:
+      - "traefik.backend=medtagger_frontend"
+      - "traefik.frontend.rule=PathPrefix: /"
 
   medtagger_backend_rest:
     image: medtagger_backend/rest
@@ -67,10 +76,11 @@ services:
       - MEDTAGGER__API_DEBUG=1
       - MEDTAGGER__API_SECRET_KEY=SECRET_KEY
       - MEDTAGGER__DB_DATABASE_URI=postgresql://medtagger_user:MedTa99er!@postgres:5432/medtagger
+      - MEDTAGGER__DB_CONNECTION_POOL_SIZE=10
       - MEDTAGGER__HBASE_HOST=hbase
       - MEDTAGGER__HBASE_PORT=9090
       - MEDTAGGER__HBASE_REST_PORT=8080
-      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=25
+      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=4
       - MEDTAGGER__CELERY_BROKER=pyamqp://guest:guest@rabbitmq//
     build:
       context: backend
@@ -84,6 +94,9 @@ services:
       - medtagger_backend_websocket
       - medtagger_backend_worker
     command: bash -c "./scripts/wait_for_dependencies.sh && ./scripts/dev__prepare_backend.sh && make run_rest_production"
+    labels:
+      - "traefik.backend=medtagger_backend_rest"
+      - "traefik.frontend.rule=PathPrefix: /api/v1/,/swaggerui/"
 
   medtagger_backend_websocket:
     image: medtagger_backend/websocket
@@ -94,10 +107,11 @@ services:
       - MEDTAGGER__API_DEBUG=1
       - MEDTAGGER__API_SECRET_KEY=SECRET_KEY
       - MEDTAGGER__DB_DATABASE_URI=postgresql://medtagger_user:MedTa99er!@postgres:5432/medtagger
+      - MEDTAGGER__DB_CONNECTION_POOL_SIZE=10
       - MEDTAGGER__HBASE_HOST=hbase
       - MEDTAGGER__HBASE_PORT=9090
       - MEDTAGGER__HBASE_REST_PORT=8080
-      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=25
+      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=4
       - MEDTAGGER__CELERY_BROKER=pyamqp://guest:guest@rabbitmq//
     build:
       context: backend
@@ -109,6 +123,11 @@ services:
       - rabbitmq
       - postgres
     command: bash -c "./scripts/wait_for_dependencies.sh && ./scripts/dev__prepare_backend.sh && make run_websocket_production"
+    labels:
+      - "traefik.backend=medtagger_backend_websocket"
+      - "traefik.backend.loadbalancer.stickiness=true"
+      - "traefik.backend.loadbalancer.stickiness.cookieName=MEDTAGER_WEBSOCKET_NODE"
+      - "traefik.frontend.rule=PathPrefix: /socket.io"
 
   medtagger_backend_worker:
     image: medtagger_backend/worker
@@ -119,10 +138,11 @@ services:
       - MEDTAGGER__API_DEBUG=1
       - MEDTAGGER__API_SECRET_KEY=SECRET_KEY
       - MEDTAGGER__DB_DATABASE_URI=postgresql://medtagger_user:MedTa99er!@postgres:5432/medtagger
+      - MEDTAGGER__DB_CONNECTION_POOL_SIZE=10
       - MEDTAGGER__HBASE_HOST=hbase
       - MEDTAGGER__HBASE_PORT=9090
       - MEDTAGGER__HBASE_REST_PORT=8080
-      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=10
+      - MEDTAGGER__HBASE_CONNECTION_POOL_SIZE=4
       - MEDTAGGER__CELERY_BROKER=pyamqp://guest:guest@rabbitmq//
     build:
       context: backend
@@ -134,6 +154,8 @@ services:
       - rabbitmq
       - postgres
     command: bash -c "./scripts/wait_for_dependencies.sh && ./scripts/dev__prepare_backend.sh && make run_workers"
+    labels:
+      - "traefik.enable=false"
 
 volumes:
   hbase-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   reverse-proxy:
     image: traefik
-    command: --debug --configFile=/var/traefik/traefik.toml
+    command: --configFile=/var/traefik/traefik.toml
     ports:
       - 80:80
       - 7128:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3'
+
 services:
+  reverse-proxy:
+    image: traefik
+    command: --configFile=/var/traefik/traefik.toml
+    ports:
+      - 80:80
+      - 7128:8080
+    volumes:
+      - $PWD/traefik.toml:/var/traefik/traefik.toml
+      - /var/run/docker.sock:/var/run/docker.sock
+
   hbase:
     image: dajobe/hbase
     volumes:

--- a/docs/setup_with_docker_compose.md
+++ b/docs/setup_with_docker_compose.md
@@ -33,6 +33,23 @@ $ docker-compose up
 
 _**TIP!**_ Add `-d` (detach) option to run everything in the background!
 
+### How to scale MedTagger with multiple containers?
+
+MedTagger was designed to be as much scalable as possible. As an administrator you can define how many
+ containers you would like to run for each of our service. Whole load will be balanced across all
+ available resources. To do so, you can run:
+
+```bash
+$ docker-compose up -d \
+   --scale medtagger_backend_websocket=4 \
+   --scale medtagger_backend_rest=2 \
+   --scale medtagger_backend_worker=2 \
+   --scale medtagger_frontend=2
+```
+
+Remember that each service may run on multiple processes on its own, so be reasonable about
+ resource allocation!
+
 ### How to update MedTagger in Docker?
 
 To update MedTagger using Docker Compose please use below `up` command with `--build` switch:

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -26,28 +26,4 @@ server {
     try_files $uri $uri/ /index.html =404;
   }
 
-  location ~ ^/(api|swaggerui)/ {
-    proxy_pass         http://medtagger_backend_rest:51000;
-    proxy_redirect     off;
-
-    proxy_set_header   Host              $host;
-    proxy_set_header   X-Real-IP         $remote_addr;
-    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Proto $scheme;
-  }
-
-  location /socket.io {
-    proxy_pass         http://medtagger_backend_websocket:51001;
-    proxy_redirect     off;
-    proxy_http_version 1.1;
-
-    add_header Access-Control-Allow-Origin *;
-
-    proxy_set_header   Host              $host;
-    proxy_set_header   X-Real-IP         $remote_addr;
-    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Proto $scheme;
-    proxy_set_header   Upgrade           $http_upgrade;
-    proxy_set_header   Connection        $connection_upgrade;
-  }
 }

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,0 +1,16 @@
+[traefikLog]
+filePath = "/path/to/traefik.log"
+
+[accessLog]
+
+logLevel = "DEBUG"
+
+[api]
+dashboard = true
+debug = true
+address = ":7128"
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+domain = "docker.localhost"
+watch = true

--- a/traefik.toml
+++ b/traefik.toml
@@ -2,7 +2,7 @@
 filePath = "/var/traefik/traefik.log"
 
 [accessLog]
-logLevel = "DEBUG"
+logLevel = "INFO"
 
 defaultEntryPoints = ["http", "ws"]
 

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,9 +1,10 @@
 [traefikLog]
-filePath = "/path/to/traefik.log"
+filePath = "/var/traefik/traefik.log"
 
 [accessLog]
-
 logLevel = "DEBUG"
+
+defaultEntryPoints = ["http", "ws"]
 
 [api]
 dashboard = true
@@ -14,3 +15,8 @@ address = ":7128"
 endpoint = "unix:///var/run/docker.sock"
 domain = "docker.localhost"
 watch = true
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+


### PR DESCRIPTION
Fixes #123

## Proposed Changes

  - Replace Nginx with Traefik for handling connections to REST API and WebSocket,
  - Load balance traffic on WebSockets between mutliple containers.
