### PR TITLE
Revert "[Backend Dependencies Update] Update gevent to 1.3.0"

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ flask-login==0.4.1
 Flask-HTTPAuth==3.2.3
 passlib==1.7.1
 uWSGI==2.0.17
-gevent==1.3.0
+gevent==1.2.2
 cassandra-driver==3.14.0
 SimpleITK==1.1.0
 numpy==1.14.3


### PR DESCRIPTION
Reverts jpowie01/MedTagger#259 due to incompatibility with uWSGI:
https://github.com/unbit/uwsgi/issues/1790