### PR TITLE
Fix issues with retrying during Scans upload

### DIFF
--- a/backend/medtagger/api/exceptions.py
+++ b/backend/medtagger/api/exceptions.py
@@ -29,3 +29,9 @@ class AccessForbiddenException(BaseHTTPException):
     """Exception designed to use while the user does not have a privilege to perform action."""
 
     pass
+
+
+class InternalErrorException(BaseHTTPException):
+    """Exception designed to use to indicate internal errors (like DB/Storage error)."""
+
+    pass

--- a/backend/medtagger/api/scans/business.py
+++ b/backend/medtagger/api/scans/business.py
@@ -3,11 +3,12 @@ import io
 import logging
 from typing import Callable, Iterable, Dict, List, Tuple, Any
 
+from cassandra import WriteTimeout
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from PIL import Image
 
-from medtagger.api.exceptions import NotFoundException, InvalidArgumentsException
+from medtagger.api.exceptions import NotFoundException, InvalidArgumentsException, InternalErrorException
 from medtagger.repositories.label_tag import LabelTagRepository
 from medtagger.types import ScanID, LabelPosition, LabelShape, LabelingTime, LabelID
 from medtagger.database.models import ScanCategory, Scan, Slice, Label, LabelTag, SliceOrientation
@@ -226,7 +227,11 @@ def add_new_slice(scan_id: ScanID, image: bytes) -> Slice:
     """
     scan = ScansRepository.get_scan_by_id(scan_id)
     _slice = scan.add_slice()
-    SlicesRepository.store_original_image(_slice.id, image)
+    try:
+        SlicesRepository.store_original_image(_slice.id, image)
+    except WriteTimeout:
+        SlicesRepository.delete_slice_by_id(_slice.id)
+        raise InternalErrorException('Timeout during saving original image to the Storage.')
     parse_dicom_and_update_slice.delay(_slice.id)
     return _slice
 

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -140,14 +140,13 @@ export class ScanService {
                 .pipe(
                     retryWhen((error: Observable<HttpErrorResponse>) => {
                         return error.pipe(
-                            flatMap((scanRequestError: HttpErrorResponse) => {
+                            map((scanRequestError: HttpErrorResponse) => {
                                 console.warn('Retrying request for creating new Scan (attempt: ' + (++retryAttempt) + ').');
-                                return of(scanRequestError.status).pipe(
-                                    delay(5000), // Let's give it a try after 5 seconds
-                                    take(5), // Let's give it 5 retries (each after 5 seconds)
-                                    concat(observableThrowError({error: 'Cannot create new Scan.'}))
-                                );
+                                return of(scanRequestError.status);
                             }),
+                            delay(5000), // Let's give it a try after 5 seconds
+                            take(5), // Let's give it 5 retries (each after 5 seconds)
+                            concat(observableThrowError({error: 'Cannot create new Scan.'}))
                         );
                     })
                 ).toPromise().then(
@@ -166,7 +165,7 @@ export class ScanService {
 
         return from(files).pipe(
             map((file: File) => {
-                console.log('uploading...', file);
+                console.log('Uploading file...', file);
                 let retryAttempt = 0;
                 const form = new FormData();
                 form.append('image', file, file.name);
@@ -175,16 +174,14 @@ export class ScanService {
                         .pipe(
                             retryWhen((error: Observable<HttpErrorResponse>) => {
                                 return error.pipe(
-                                    flatMap((uploadRequestError: HttpErrorResponse) => {
+                                    map((uploadRequestError: HttpErrorResponse) => {
                                         console.warn('Retrying request for uploading a single Slice ('
                                             + file.name + ', attempt: ' + (++retryAttempt) + ').');
-                                        return of(uploadRequestError.status).pipe(
-                                            delay(5000),  // Let's give it a try after 5 seconds
-                                            take(5),  // Let's give it 5 retries (each after 5 seconds)
-                                            concat(observableThrowError({error: 'Cannot upload Slice ' + file.name}))
-                                            // TODO: use some new way of dealing with
-                                        );
-                                    })
+                                        return of(uploadRequestError.status);
+                                    }),
+                                    delay(5000),  // Let's give it a try after 5 seconds
+                                    take(5),  // Let's give it 5 retries (each after 5 seconds)
+                                    concat(observableThrowError({error: 'Cannot upload Slice ' + file.name}))
                                 );
                             })
                         )


### PR DESCRIPTION
## Proposed Changes

  - Retrying on the UI side was broken after migration to Angular 6,
  - Slice upload could fail while saving file to the Storage, leaving invalid Slice object in the SQL DB,
  - Added a functional test for retrying upload.