### PR TITLE
Fix linter issues - useless object inheritance

### DIFF
--- a/backend/medtagger/config.py
+++ b/backend/medtagger/config.py
@@ -3,7 +3,7 @@ import os
 from typing import Any
 
 
-class AppConfiguration(object):
+class AppConfiguration:
     """Class that represents application configuration."""
 
     def __init__(self) -> None:

--- a/backend/medtagger/database/__init__.py
+++ b/backend/medtagger/database/__init__.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from medtagger.config import AppConfiguration
 
 
-class MedTaggerBase(object):  # pylint: disable=too-few-public-methods
+class MedTaggerBase:  # pylint: disable=too-few-public-methods
     """Base class for all of the models."""
 
     _created = Column(DateTime, nullable=False, server_default=func.now(), default=datetime.utcnow)


### PR DESCRIPTION
Fixes backend linter errors (useless object inheritance)

## Proposed Changes

  - No need to explicitly inherit from `object`, as it is done for us implicitly.

