### PR TITLE
Change logo path so that it's properly displayed.

### DIFF
--- a/frontend/src/app/pages/login-page/login-page.component.html
+++ b/frontend/src/app/pages/login-page/login-page.component.html
@@ -1,7 +1,7 @@
 <div class="row">
     <header class="col-sm-12 col-lg-4">
         <div class="logo">
-            <img src="../../../assets/icon/medtagger_logo.svg"/>
+            <img src="assets/icon/medtagger_logo.svg"/>
             <h1>MedTagger</h1>
         </div>
         <h3>The open-source platform for labeling and aggregation of datasets with usage of a crowdsourcing idea.</h3>


### PR DESCRIPTION
## Proposed Changes

  - Logo path was fine as long as we didn't run project from any subdirectories (like we do at kask.eti.pg.edu.pl/medtagger). Because of that, browser tried to get the image skipping the medtagger subdirectory:

![image](https://user-images.githubusercontent.com/16022081/43565816-70922b84-962c-11e8-9127-93be4b9f81fb.png)

After this change, path to image is relative to current location, hence the image is displayed properly.

