### PR TITLE
Added verification of current Selector's availability on Label Tag change.

### DIFF
--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -88,6 +88,10 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
         super.setCurrentTagForSelector(this.currentSelector, this.currentTag);
     }
 
+    public clearCurrentSelector() {
+        this.currentSelector = undefined;
+    }
+
     public setCurrentTag(tag: LabelTag) {
         super.setCurrentTag(tag);
         this.currentTag = tag;

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -253,7 +253,7 @@ export class MarkerPageComponent implements OnInit {
         this.marker.setCurrentTag(tag);
         const currentSelector = this.marker.getCurrentSelector();
         if (!isUndefined(currentSelector)) {
-            if(!this.isToolSupportedByCurrentTag(currentSelector.getSelectorName())) {
+            if (!this.isToolSupportedByCurrentTag(currentSelector.getSelectorName())) {
                 this.clearSelector();
             }
         }

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -244,8 +244,19 @@ export class MarkerPageComponent implements OnInit {
         }
     }
 
+    public clearSelector() {
+        this.marker.clearCurrentSelector();
+        this.selectorActions = [];
+    }
+
     public setTag(tag: LabelTag) {
         this.marker.setCurrentTag(tag);
+        const currentSelector = this.marker.getCurrentSelector();
+        if (!isUndefined(currentSelector)) {
+            if(!this.isToolSupportedByCurrentTag(currentSelector.getSelectorName())) {
+                this.clearSelector();
+            }
+        }
     }
 
     public getToolIconName(iconName: string): string {


### PR DESCRIPTION
Fixes #379

## Proposed Changes

  - Before that change, it was not verified whether currently chosen Selector (a.k.a. Tool) was available for the Tag we were switching to, thus allowing users to use Tools technically not available for the Tag chosen.
After the change, it is verified, and if currently chosen Tool happens to not be available for the new Tag, Tool is unselected and user needs to choose new one from list of available tools for the new Tag.
