### PR TITLE
Remove category dialog

### DIFF
--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -1,10 +1,14 @@
 """Module responsible for business logic in all Tasks endpoints."""
 from typing import List
 
+from sqlalchemy.orm.exc import NoResultFound
+
+from medtagger.api.exceptions import NotFoundException
 from medtagger.database.models import Task, LabelTag
 from medtagger.repositories import (
     tasks as TasksRepository,
 )
+
 
 
 def get_tasks() -> List[Task]:
@@ -14,6 +18,15 @@ def get_tasks() -> List[Task]:
     """
     return TasksRepository.get_all_tasks()
 
+def get_task_for_key(task_key: str) -> Task:
+    """Fetch Task for given key.
+
+    :return: Task
+    """
+    try:
+        return TasksRepository.get_task_by_key(task_key)
+    except NoResultFound:
+        raise NotFoundException('Did not found task for {} key!'.format(task_key))
 
 def create_task(key: str, name: str, image_path: str, categories_keys: List[str], tags: List[LabelTag]) -> Task:
     """Create new Task.

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -10,13 +10,13 @@ from medtagger.repositories import (
 )
 
 
-
 def get_tasks() -> List[Task]:
     """Fetch all tasks.
 
     :return: list of tasks
     """
     return TasksRepository.get_all_tasks()
+
 
 def get_task_for_key(task_key: str) -> Task:
     """Fetch Task for given key.
@@ -27,6 +27,7 @@ def get_task_for_key(task_key: str) -> Task:
         return TasksRepository.get_task_by_key(task_key)
     except NoResultFound:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
+
 
 def create_task(key: str, name: str, image_path: str, categories_keys: List[str], tags: List[LabelTag]) -> Task:
     """Create new Task.

--- a/backend/medtagger/api/tasks/service_rest.py
+++ b/backend/medtagger/api/tasks/service_rest.py
@@ -46,9 +46,10 @@ class Tasks(Resource):
 
         return business.create_task(key, name, image_path, categories_keys, tags), 201
 
+
 @tasks_ns.route('/<string:task_key>')
 class Task(Resource):
-    """Endpoint that manages single task"""
+    """Endpoint that manages single task."""
 
     @staticmethod
     @login_required

--- a/backend/medtagger/api/tasks/service_rest.py
+++ b/backend/medtagger/api/tasks/service_rest.py
@@ -45,3 +45,17 @@ class Tasks(Resource):
         tags = [LabelTag(tag['key'], tag['name'], tag['tools']) for tag in payload['tags']]
 
         return business.create_task(key, name, image_path, categories_keys, tags), 201
+
+@tasks_ns.route('/<string:task_key>')
+class Task(Resource):
+    """Endpoint that manages single task"""
+
+    @staticmethod
+    @login_required
+    @tasks_ns.marshal_with(serializers.out__task)
+    @tasks_ns.doc(security='token')
+    @tasks_ns.doc(description='Get category for given key.')
+    @tasks_ns.doc(responses={201: 'Success', 404: 'Could not find task'})
+    def get(task_key: str) -> Any:
+        """Return task for given key."""
+        return business.get_task_for_key(task_key)

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -10,7 +10,7 @@ import {RectROISelector} from '../../components/selectors/RectROISelector';
 import {ROISelection2D} from '../../model/ROISelection2D';
 import {SliceRequest} from '../../model/SliceRequest';
 import {DialogService} from '../../services/dialog.service';
-import {Location} from '@angular/common';
+import {Router} from '@angular/router';
 import {MatSnackBar} from '@angular/material';
 import {LabelTag} from '../../model/LabelTag';
 import {LabelExplorerComponent} from '../../components/label-explorer/label-explorer.component';
@@ -48,9 +48,10 @@ export class MarkerPageComponent implements OnInit {
     selectorActions: Array<SelectorAction> = [];
     labelComment: string;
     isInitialSliceLoad: boolean;
+    chooseTaskPageUrl = '/labelling/choose-task';
 
     constructor(private scanService: ScanService, private route: ActivatedRoute, private dialogService: DialogService,
-                private location: Location, private snackBar: MatSnackBar, private taskService: TaskService) {
+                private router: Router, private snackBar: MatSnackBar, private taskService: TaskService) {
         console.log('MarkerPage constructor', this.marker);
         this.labelComment = '';
         this.isInitialSliceLoad = true;
@@ -72,7 +73,7 @@ export class MarkerPageComponent implements OnInit {
                         .openInfoDialog('There are no tags assigned to this task!', 'Please try another task!', 'Go back')
                         .afterClosed()
                         .subscribe(() => {
-                            this.location.back();
+                            this.router.navigateByUrl(this.chooseTaskPageUrl);
                         });
                 }
             },
@@ -82,7 +83,7 @@ export class MarkerPageComponent implements OnInit {
                         .openInfoDialog('You did not choose task properly!', 'Please choose it again!', 'Go back')
                         .afterClosed()
                         .subscribe(() => {
-                            this.location.back();
+                            this.router.navigateByUrl(this.chooseTaskPageUrl);
                         });
                 }
             });
@@ -170,7 +171,7 @@ export class MarkerPageComponent implements OnInit {
                     .openInfoDialog('Nothing to do here!', 'No more Scans available for you in this category!', 'Go back')
                     .afterClosed()
                     .subscribe(() => {
-                        this.location.back();
+                        this.router.navigateByUrl(this.chooseTaskPageUrl);
                     });
             });
     }

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -66,21 +66,26 @@ export class MarkerPageComponent implements OnInit {
         this.taskService.getCurrentTask(this.taskKey).then(
             (task: Task) => {
                 this.task = task;
+                console.log("asdsad", this.task);
                 this.taskTags = new FormControl('', [Validators.required]);
-            },
-            (errorResponse: Error) => {
-                console.log(errorResponse);
-            });
 
-        if (this.task.tags.length === 0) {
-            this.dialogService
-                .openInfoDialog('There are no tags assigned to this task!', 'Please try another task!', 'Go back')
-                .afterClosed()
-                .subscribe(() => {
-                    this.location.back();
-                });
-        }
-
+                if (!this.task) {
+                    this.dialogService
+                        .openInfoDialog('You did not choose task properly!', 'Please choose it again!', 'Go back')
+                        .afterClosed()
+                        .subscribe(() => {
+                            this.location.back();
+                    });
+                } else if (this.task.tags.length === 0) {
+                    this.dialogService
+                        .openInfoDialog('There are no tags assigned to this task!', 'Please try another task!', 'Go back')
+                        .afterClosed()
+                        .subscribe(() => {
+                            this.location.back();
+                        }
+                    );
+                }
+        });
 
         this.selectors = new Map<string, Selector<any>>([
             ['RECTANGLE', new RectROISelector(this.marker.getCanvas())],

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -66,26 +66,28 @@ export class MarkerPageComponent implements OnInit {
         this.taskService.getCurrentTask(this.taskKey).then(
             (task: Task) => {
                 this.task = task;
-                console.log("asdsad", this.task);
-                this.taskTags = new FormControl('', [Validators.required]);
 
+                if (this.task.tags.length === 0) {
+                    this.dialogService
+                        .openInfoDialog('There are no tags assigned to this task!', 'Please try another task!', 'Go back')
+                        .afterClosed()
+                        .subscribe(() => {
+                            this.location.back();
+                        });
+                }
+            },
+            (errorResponse: Error) => {
                 if (!this.task) {
                     this.dialogService
                         .openInfoDialog('You did not choose task properly!', 'Please choose it again!', 'Go back')
                         .afterClosed()
                         .subscribe(() => {
                             this.location.back();
-                    });
-                } else if (this.task.tags.length === 0) {
-                    this.dialogService
-                        .openInfoDialog('There are no tags assigned to this task!', 'Please try another task!', 'Go back')
-                        .afterClosed()
-                        .subscribe(() => {
-                            this.location.back();
-                        }
-                    );
+                        });
                 }
-        });
+            });
+
+        this.taskTags = new FormControl('', [Validators.required]);
 
         this.selectors = new Map<string, Selector<any>>([
             ['RECTANGLE', new RectROISelector(this.marker.getCanvas())],
@@ -149,7 +151,7 @@ export class MarkerPageComponent implements OnInit {
 
     private requestScan(): void {
         this.marker.setDownloadScanInProgress(true);
-        this.scanService.getRandomScan(this.task.key).then(
+        this.scanService.getRandomScan(this.taskKey).then(
             (scan: ScanMetadata) => {
                 this.scan = scan;
                 this.marker.setScanMetadata(this.scan);

--- a/frontend/src/app/pages/tasks-page/tasks-page.component.html
+++ b/frontend/src/app/pages/tasks-page/tasks-page.component.html
@@ -9,7 +9,7 @@
        <button mat-button id="back-button" color="accent" routerLink="/home">Go back</button>
     </div>
     <div class="button-row" *ngIf="!downloadingTasksInProgress && tasks?.length > 0">
-        <button mat-fab *ngFor="let task of tasks" routerLink="/labelling" (click)="setCurrentTask(task)">
+        <button mat-fab *ngFor="let task of tasks" routerLink="/labelling" [queryParams]="{task: task.key}">
             <mat-icon svgIcon="{{task.key}}"></mat-icon>
             <div>{{task.name}}</div>
         </button>

--- a/frontend/src/app/pages/tasks-page/tasks-page.component.ts
+++ b/frontend/src/app/pages/tasks-page/tasks-page.component.ts
@@ -3,7 +3,6 @@ import {MatSnackBar, MatIconRegistry} from '@angular/material';
 import {DomSanitizer} from '@angular/platform-browser';
 
 import {TaskService} from '../../services/task.service';
-import {Task} from '../../model/Task';
 
 @Component({
     selector: 'app-tasks-page',
@@ -32,9 +31,5 @@ export class TasksPageComponent implements OnInit {
                 duration: 5000,
             });
         });
-    }
-
-    public setCurrentTask(task: Task) {
-        this.taskService.setCurrentTask(task);
     }
 }

--- a/frontend/src/app/services/task.service.ts
+++ b/frontend/src/app/services/task.service.ts
@@ -1,8 +1,8 @@
-import {Injectable} from '@angular/core';
-import {environment} from '../../environments/environment';
-import {Task} from '../model/Task';
-import {HttpClient} from '@angular/common/http';
-import {LabelTag} from '../model/LabelTag';
+import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+import { Task } from '../model/Task';
+import { HttpClient } from '@angular/common/http';
+import { LabelTag } from '../model/LabelTag';
 
 export interface TaskResponse {
     task_id: number;
@@ -23,22 +23,27 @@ interface LabelTagResponse {
 @Injectable()
 export class TaskService {
 
-    constructor(private http: HttpClient) {}
+    tasks: Array<Task> = [];
+    constructor(private http: HttpClient) { }
 
     getCurrentTask(taskKey: string): Promise<Task> {
-        return new Promise((resolve, reject) => {
-            this.http.get<TaskResponse>(environment.API_URL + '/tasks/' + taskKey).toPromise().then(
-                response => {
-                    console.log('ScanService | getCurrentTask | response: ', response);
-                    const tags = response.tags.map(tag => new LabelTag(tag.key, tag.name, tag.tools));
-                    resolve(new Task(response.task_id, response.key, response.name, response.image_path, tags));
-                },
-                error => {
-                    console.log('ScanService | getCurrentTask | error: ', error);
-                    reject(error);
-                }
-            );
-        });
+        if (this.tasks.length > 0) {
+           return Promise.resolve(this.tasks.find(task => task.key === taskKey));
+        } else {
+            return new Promise((resolve, reject) => {
+                this.http.get<TaskResponse>(environment.API_URL + '/tasks/' + taskKey).toPromise().then(
+                    response => {
+                        console.log('ScanService | getCurrentTask | response: ', response);
+                        const tags = response.tags.map(tag => new LabelTag(tag.key, tag.name, tag.tools));
+                        resolve(new Task(response.task_id, response.key, response.name, response.image_path, tags));
+                    },
+                    error => {
+                        console.log('ScanService | getCurrentTask | error: ', error);
+                        reject(error);
+                    }
+                );
+            });
+        }
     }
 
     getTasks(): Promise<Task[]> {
@@ -46,12 +51,11 @@ export class TaskService {
             this.http.get<Array<TaskResponse>>(environment.API_URL + '/tasks').toPromise().then(
                 response => {
                     console.log('ScanService | getTasks | response: ', response);
-                    const tasks: Array<Task> = [];
                     for (const task of response) {
                         const tags = task.tags.map(tag => new LabelTag(tag.key, tag.name, tag.tools));
-                        tasks.push(new Task(task.task_id, task.key, task.name, task.image_path, tags));
+                        this.tasks.push(new Task(task.task_id, task.key, task.name, task.image_path, tags));
                     }
-                    resolve(tasks);
+                    resolve(this.tasks);
                 },
                 error => {
                     console.log('ScanService | getTasks | error: ', error);

--- a/frontend/src/app/services/task.service.ts
+++ b/frontend/src/app/services/task.service.ts
@@ -23,16 +23,22 @@ interface LabelTagResponse {
 @Injectable()
 export class TaskService {
 
-    private currentTask: Task;
-
     constructor(private http: HttpClient) {}
 
-    setCurrentTask(task: Task): void {
-        this.currentTask = task;
-    }
-
-    getCurrentTask(): Task {
-        return this.currentTask;
+    getCurrentTask(taskKey: string): Promise<Task> {
+        return new Promise((resolve, reject) => {
+            this.http.get<TaskResponse>(environment.API_URL + '/tasks/' + taskKey).toPromise().then(
+                response => {
+                    console.log('ScanService | getCurrentTask | response: ', response);
+                    const tags = response.tags.map(tag => new LabelTag(tag.key, tag.name, tag.tools));
+                    resolve(new Task(response.task_id, response.key, response.name, response.image_path, tags));
+                },
+                error => {
+                    console.log('ScanService | getCurrentTask | error: ', error);
+                    reject(error);
+                }
+            );
+        });
     }
 
     getTasks(): Promise<Task[]> {

--- a/frontend/src/app/services/task.service.ts
+++ b/frontend/src/app/services/task.service.ts
@@ -23,7 +23,7 @@ interface LabelTagResponse {
 @Injectable()
 export class TaskService {
 
-    tasks: Array<Task> = [];
+    private tasks: Array<Task> = [];
     constructor(private http: HttpClient) { }
 
     getCurrentTask(taskKey: string): Promise<Task> {
@@ -47,6 +47,9 @@ export class TaskService {
     }
 
     getTasks(): Promise<Task[]> {
+        if (this.tasks.length > 0) {
+           this.tasks = [];
+        }
         return new Promise((resolve, reject) => {
             this.http.get<Array<TaskResponse>>(environment.API_URL + '/tasks').toPromise().then(
                 response => {


### PR DESCRIPTION
Fixes #375

## Proposed Changes

  - Introduced (once more) passing task key as a query parameter,
  - Introduced two ways of getting current task:
  -- If user chose task from `choose-task` page, the task for the given key is coming from the array of 
      tasks in `task-service`,
  -- If user reloads labeling page, we are getting current task from the backend.

## API changes (optional)

Introduced new endpoint for getting single task for given key.

## Additional comment (optional)

I am not sure If i handled getting the tasks the best way I could :( Should we add some spinner or something else if we will have problems with the connection to the API when getting task?