### PR TITLE
Fix race condition during Scan upload

### DIFF
--- a/backend/medtagger/api/scans/business.py
+++ b/backend/medtagger/api/scans/business.py
@@ -249,7 +249,7 @@ def add_new_slice(scan_id: ScanID, image: bytes) -> Slice:
     """Add new Slice for given Scan.
 
     :param scan_id: ID of a Scan for which it should add new slice
-    :param image: bytes representing Dicom image
+    :param image: bytes representing DICOM image
     :return: Slice object
     """
     scan = ScansRepository.get_scan_by_id(scan_id)
@@ -257,7 +257,7 @@ def add_new_slice(scan_id: ScanID, image: bytes) -> Slice:
     try:
         SlicesRepository.store_original_image(_slice.id, image)
     except WriteTimeout:
-        SlicesRepository.delete_slice_by_id(_slice.id)
+        SlicesRepository.delete_slice(_slice)
         raise InternalErrorException('Timeout during saving original image to the Storage.')
     parse_dicom_and_update_slice.delay(_slice.id)
     return _slice

--- a/backend/medtagger/repositories/scans.py
+++ b/backend/medtagger/repositories/scans.py
@@ -59,14 +59,6 @@ def add_new_scan(category: ScanCategory, number_of_slices: int, user: Optional[U
     return scan
 
 
-def reduce_number_of_declared_slices(scan_id: ScanID) -> None:
-    """Decrease number of declared Slices by one."""
-    with db_session() as session:
-        query = session.query(Scan)
-        query = query.filter(Scan.id == scan_id)
-        query.update({"declared_number_of_slices": (Scan.declared_number_of_slices - 1)})
-
-
 def try_to_mark_scan_as_stored(scan_id: ScanID) -> bool:
     """Mark Scan as STORED only if all Slices were STORED.
 

--- a/backend/medtagger/repositories/slices.py
+++ b/backend/medtagger/repositories/slices.py
@@ -28,11 +28,9 @@ def get_slices_by_scan_id(scan_id: ScanID, orientation: SliceOrientation = Slice
 
 def delete_slice(_slice: Slice) -> None:
     """Remove Slice from SQL database and Storage."""
-    delete_slice_by_id(_slice.id, _slice.scan_id)
+    slice_id = _slice.id
+    scan_id = _slice.scan_id
 
-
-def delete_slice_by_id(slice_id: SliceID, scan_id: ScanID) -> None:
-    """Remove Slice from SQL database and Storage based on IDs."""
     with db_session() as session:
         query = session.query(Scan).filter(Scan.id == scan_id)
         query.update({'declared_number_of_slices': Scan.declared_number_of_slices - 1})

--- a/backend/medtagger/repositories/slices.py
+++ b/backend/medtagger/repositories/slices.py
@@ -26,10 +26,18 @@ def get_slices_by_scan_id(scan_id: ScanID, orientation: SliceOrientation = Slice
     return slices
 
 
-def delete_slice_by_id(slice_id: SliceID) -> None:
+def delete_slice(_slice: Slice) -> None:
     """Remove Slice from SQL database and Storage."""
+    delete_slice_by_id(_slice.id, _slice.scan_id)
+
+
+def delete_slice_by_id(slice_id: SliceID, scan_id: ScanID) -> None:
+    """Remove Slice from SQL database and Storage based on IDs."""
     with db_session() as session:
+        query = session.query(Scan).filter(Scan.id == scan_id)
+        query.update({'declared_number_of_slices': Scan.declared_number_of_slices - 1})
         session.query(Slice).filter(Slice.id == slice_id).delete()
+
     OriginalSlice.filter(id=slice_id).delete()
     ProcessedSlice.filter(id=slice_id).delete()
 

--- a/backend/medtagger/workers/storage.py
+++ b/backend/medtagger/workers/storage.py
@@ -44,9 +44,8 @@ def parse_dicom_and_update_slice(slice_id: SliceID) -> None:
 
     except RuntimeError:
         logger.error('User sent a file that is not a DICOM.')
-        SlicesRepository.delete_slice_by_id(_slice.id)
-        ScansRepository.reduce_number_of_declared_slices(_slice.scan_id)
         os.unlink(temp_file.name)
+        SlicesRepository.delete_slice(_slice)
         trigger_scan_conversion_if_needed(_slice.scan_id)
         return
 


### PR DESCRIPTION
Fixes #376 

## Proposed Changes

  - Upload Scan could stuck due to mismatch between uploaded Slices and declared number of Slices,
  - It could happen in case of a race condition between deleting Slice from the DB and decreasing declared number of Slices,
  - Declared number of Slices was not decreased in case of a timeout while saving to Cassandra DB,
  - Deleting and decreasing value moved into one method and SQL Transaction just to be sure there won't be any race conditions any more!

