### PR TITLE
Fixes for login and registration forms

### DIFF
--- a/backend/medtagger/api/auth/business.py
+++ b/backend/medtagger/api/auth/business.py
@@ -17,7 +17,7 @@ def create_user(email: str, password: str, first_name: str, last_name: str) -> i
     """
     user = UsersRepository.get_user_by_email(email)
     if user:
-        raise InvalidArgumentsException('User with this email already exist')
+        raise InvalidArgumentsException('User with this email already exists')
     password_hash = hash_password(password)
     new_user = User(email, password_hash, first_name, last_name)
     role = RolesRepository.get_role_with_name('volunteer')

--- a/backend/tests/unit_tests/api/auth/test_business.py
+++ b/backend/tests/unit_tests/api/auth/test_business.py
@@ -51,7 +51,7 @@ def test_create_user_user_exists(mocker: Any, get_user_by_email_success_fixture:
 
     with pytest.raises(InvalidArgumentsException) as exception:
         create_user(email, password, first_name, last_name)
-    assert str(exception.value) == 'User with this email already exist'
+    assert str(exception.value) == 'User with this email already exists'
 
 
 def test_create_user_missing_role(mocker: Any, get_user_by_email_failure_fixture: Any, get_role_fixture: Any) -> None:

--- a/frontend/src/app/pages/login-page/login-page.component.html
+++ b/frontend/src/app/pages/login-page/login-page.component.html
@@ -11,11 +11,11 @@
     <div class="d-none d-lg-block col-lg-4"></div>
     <div class="col-sm-12 col-lg-8 action">
         <div class="action-buttons">
-            <h4 [ngClass]="{active: loginPageMode == LoginPageMode.REGISTER}" (click)="changePageMode()">
-                <a routerLink="/login">Sign up</a>
-            </h4>
-            <h4 [ngClass]="{active: loginPageMode == LoginPageMode.LOG_IN}" (click)="changePageMode()">
+            <h4 [ngClass]="{active: loginPageMode == LoginPageMode.LOG_IN}" (click)="changePageMode(LoginPageMode.LOG_IN)">
                 <a routerLink="/login">Sign in</a>
+            </h4>
+            <h4 [ngClass]="{active: loginPageMode == LoginPageMode.REGISTER}" (click)="changePageMode(LoginPageMode.REGISTER)">
+                <a routerLink="/login">Sign up</a>
             </h4>
         </div>
         <main *ngIf="loginPageMode == LoginPageMode.LOG_IN" class="action-content mx-auto">
@@ -23,30 +23,33 @@
                     <h3 class="action-welcoming__header">Hello!</h3>
                     <h4 class="action-welcoming__description">Good to see you back! Log in and continue your work.</h4>
                 </div>
-                <form class="action-form" [formGroup]="userForm" (keyup.enter)="logIn()">
+                <form class="action-form" [formGroup]="loginForm" (keyup.enter)="logIn()">
                     <mat-form-field appearance="fill">
                         <mat-label>Email</mat-label>
                         <input matInput type="text" placeholder="Insert your email."
                                id="email" formControlName="email" required>
-                        <mat-error *ngIf="userForm.get('email').invalid">{{getEmailErrorMessage()}}</mat-error>
+                        <mat-error *ngIf="loginForm.get('email').invalid">{{getEmailErrorMessage()}}</mat-error>
                     </mat-form-field>
                     <mat-form-field appearance="fill">
                         <mat-label>Password</mat-label>
                         <input matInput type="{{loginPasswordVisible && 'text' || 'password'}}"
                                placeholder="Insert your password."
                                id="password" formControlName="password" required>
-                        <mat-error *ngIf="userForm.get('password').invalid">{{getPasswordErrorMessage()}}</mat-error>
+                        <mat-error *ngIf="loginForm.get('password').invalid">{{getPasswordErrorMessage()}}</mat-error>
                         <mat-icon matSuffix (click)="changeVisibility()">visibility</mat-icon>
                     </mat-form-field>
+                    <div class="action-form__submit">
+                        <button *ngIf="!loggingInProgress" mat-raised-button color="primary" (click)="logIn()" [disabled]="loginForm.invalid">
+                            Sign in
+                        </button>
+                        <mat-progress-spinner *ngIf="loggingInProgress" class="login-spinner" mode="indeterminate"
+                                              [diameter]="36" strokeWidth="2"></mat-progress-spinner>
+                    </div>
+                    <div *ngIf="loggingInError !== undefined" class="action-form__error">
+                        <mat-icon color="warn">error</mat-icon>
+                        <mat-error>{{loggingInError}}</mat-error>
+                    </div>
                 </form>
-                <div class="action-form__submit">
-                    <button *ngIf="!loggingInProgress" mat-raised-button color="primary" (click)="logIn()">
-                        Sign in
-                    </button>
-                    <mat-progress-spinner *ngIf="loggingInProgress" class="login-spinner" mode="indeterminate"
-                                          [diameter]="36" strokeWidth="2"></mat-progress-spinner>
-                    <mat-icon *ngIf="loggingInError" color="warn">error</mat-icon>
-                </div>
         </main>
 
 
@@ -57,20 +60,20 @@
                         your time and fill this registration form and
                         you are ready to go. </h4>
                 </div>
-                <form class="action-form" [formGroup]="userForm" (keyup.enter)="register()">
+                <form class="action-form" [formGroup]="registerForm" (keyup.enter)="register()">
                     <div class="row">
                         <mat-form-field appearance="fill" class="col-12 col-lg-6">
                             <mat-label>First name</mat-label>
                             <input matInput type="text" placeholder="Insert your name."
                                    id="firstName" formControlName="firstName" required>
-                            <mat-error *ngIf="userForm.get('firstName').invalid">{{getFirstNameErrorMessage()}}
+                            <mat-error *ngIf="registerForm.get('firstName').invalid">{{getFirstNameErrorMessage()}}
                             </mat-error>
                         </mat-form-field>
                         <mat-form-field appearance="fill" class="col-12 col-lg-6">
                             <mat-label>Last name</mat-label>
                             <input matInput type="text" placeholder="Insert your surname."
                                    id="lastName" formControlName="lastName" required>
-                            <mat-error *ngIf="userForm.get('lastName').invalid">{{getLastNameErrorMessage()}}
+                            <mat-error *ngIf="registerForm.get('lastName').invalid">{{getLastNameErrorMessage()}}
                             </mat-error>
                         </mat-form-field>
                     </div>
@@ -78,14 +81,14 @@
                         <mat-label>Email</mat-label>
                         <input matInput type="text" placeholder="Insert your email."
                                id="email" formControlName="email" required>
-                        <mat-error *ngIf="userForm.get('email').invalid">{{getEmailErrorMessage()}}</mat-error>
+                        <mat-error *ngIf="registerForm.get('email').invalid">{{getEmailErrorMessage()}}</mat-error>
                     </mat-form-field>
                     <mat-form-field appearance="fill">
                         <mat-label>Password</mat-label>
                         <input matInput type="{{registerPasswordVisible && 'text' || 'password'}}"
                                placeholder="Enter your password."
                                id="password" formControlName="password" required>
-                        <mat-error *ngIf="userForm.get('password').invalid">{{getPasswordErrorMessage()}}</mat-error>
+                        <mat-error *ngIf="registerForm.get('password').invalid">{{getPasswordErrorMessage()}}</mat-error>
                         <mat-icon matSuffix (click)="changeVisibility()">visibility</mat-icon>
                     </mat-form-field>
                     <mat-form-field appearance="fill">
@@ -93,18 +96,23 @@
                         <input matInput type="{{registerPasswordVisible && 'text' || 'password'}}"
                                placeholder="Re-enter your password."
                                id="confirmPassword" formControlName="confirmPassword" required>
-                        <mat-error *ngIf="userForm.get('password').invalid">{{getConfirmPasswordErrorMessage()}}
+                        <mat-error *ngIf="registerForm.get('password').invalid">{{getConfirmPasswordErrorMessage()}}
                         </mat-error>
                         <mat-icon matSuffix (click)="changeVisibility()">visibility</mat-icon>
                     </mat-form-field>
+                    <div class="action-form__submit">
+                        <button *ngIf="!registrationInProgress" mat-raised-button color="primary" (click)="register()"
+                                [disabled]="registerForm.invalid">
+                            Sign up
+                        </button>
+                        <mat-progress-spinner *ngIf="registrationInProgress" class="login-spinner" mode="indeterminate"
+                                              [diameter]="36" strokeWidth="2"></mat-progress-spinner>
+                    </div>
+                    <div *ngIf="registrationError !== undefined" class="action-form__error">
+                        <mat-icon color="warn">error</mat-icon>
+                        <mat-error>{{registrationError}}</mat-error>
+                    </div>
                 </form>
-                <div class="action-form__submit">
-                    <button *ngIf="!registrationInProgress" mat-raised-button color="primary" (click)="register()">
-                        Sign up
-                    </button>
-                    <mat-progress-spinner *ngIf="registrationInProgress" class="login-spinner" mode="indeterminate"
-                                          [diameter]="36" strokeWidth="2"></mat-progress-spinner>
-                </div>
         </main>
     </div>
 </div>

--- a/frontend/src/app/pages/login-page/login-page.component.scss
+++ b/frontend/src/app/pages/login-page/login-page.component.scss
@@ -150,8 +150,13 @@
                     @include mat-elevation(5);
                 }
             }
+        }
+        &__error {
+            width: 100%;
+            display: flex;
+            text-align: left;
+            margin-top: 1.5em;
             mat-icon {
-                margin-left: 0.5em;
                 font-size: 1.2em;
             }
         }

--- a/frontend/src/app/pages/login-page/login-page.component.ts
+++ b/frontend/src/app/pages/login-page/login-page.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {FormControl, FormGroup, ValidationErrors, Validators} from '@angular/forms';
 import {passwordValidator} from '../validators/password-validator.directive';
 import {AccountService} from '../../services/account.service';
 
@@ -21,11 +21,13 @@ const MIN_PASSWORD_LENGTH = 8;
 export class LoginPageComponent implements OnInit {
     LoginPageMode = LoginPageMode;  // Needed in template for comparison with Enum values
     loginPageMode: LoginPageMode = LoginPageMode.LOG_IN;
-    userForm: FormGroup;
+    registerForm: FormGroup;
+    loginForm: FormGroup;
 
     loggingInProgress: boolean;
-    loggingInError: boolean;
+    loggingInError: string;
     registrationInProgress: boolean;
+    registrationError: string;
     loginPasswordVisible = false;
     registerPasswordVisible = false;
 
@@ -36,58 +38,69 @@ export class LoginPageComponent implements OnInit {
         if (this.accountService.isLoggedIn()) {
             this.routerService.navigate(['home']);
         }
-        this.userForm = new FormGroup({
+        this.registerForm = new FormGroup({
             firstName: new FormControl(null, [Validators.required]),
             lastName: new FormControl(null, [Validators.required]),
             email: new FormControl(null, [Validators.required, Validators.email]),
             password: new FormControl(null, [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)]),
             confirmPassword: new FormControl(null, [Validators.required, passwordValidator()])
         });
+        this.loginForm = new FormGroup({
+            email: new FormControl(null, [Validators.required, Validators.email]),
+            password: new FormControl(null, [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)])
+        })
     }
 
     resetLogin(): void {
+        this.loginForm.reset();
         this.loggingInProgress = false;
-        this.loggingInError = false;
+        this.loggingInError = undefined;
     }
 
     public logIn(): void {
+        if (this.loginForm.invalid) {
+            return;
+        }
+
         this.loggingInProgress = true;
-        this.loggingInError = false;
-        this.accountService.logIn(this.userForm.value['email'], this.userForm.value['password'])
+        this.loggingInError = undefined;
+        this.accountService.logIn(this.loginForm.value['email'], this.loginForm.value['password'])
             .then((token) => {
                 sessionStorage.setItem('authorizationToken', token);
                 return this.accountService.getCurrentUserInfo();
             }, (error) => {
                 this.loggingInProgress = false;
-                this.loggingInError = true;
+                this.loggingInError = error.error.details;
             })
             .then((userInfo) => {
                 this.loggingInProgress = false;
+                console.log(userInfo);
                 if (userInfo) {
                     sessionStorage.setItem('userInfo', JSON.stringify(userInfo));
                     this.routerService.navigate(['home']);
-                } else {
-                    this.loggingInError = true;
                 }
-            }, () => {
+            }, (error) => {
                 this.loggingInProgress = false;
-                this.loggingInError = true;
+                this.loggingInError = error.error.details;
             });
     }
 
-    public changePageMode(): void {
-        this.userForm.reset();
+    public changePageMode(loginPageMode: LoginPageMode): void {
+        if (loginPageMode === this.loginPageMode) {
+            return;
+        }
+
         this.loginPasswordVisible = false;
         this.registerPasswordVisible = false;
-        if (this.loginPageMode === LoginPageMode.LOG_IN) {
-            this.loginPageMode = LoginPageMode.REGISTER;
+        if (loginPageMode === LoginPageMode.LOG_IN) {
             this.resetLogin();
-        } else if (this.loginPageMode === LoginPageMode.REGISTER) {
-            this.loginPageMode = LoginPageMode.LOG_IN;
+        } else if (loginPageMode === LoginPageMode.REGISTER) {
             this.resetRegistration();
         } else {
             console.error('Unsupported login page mode!');
+            return;
         }
+        this.loginPageMode = loginPageMode;
     }
 
     public changeVisibility(): void {
@@ -101,44 +114,56 @@ export class LoginPageComponent implements OnInit {
     }
 
     getFirstNameErrorMessage(): string {
-        return this.userForm.get('firstName').hasError('required') ? 'Field required' : '';
+        return this.registerForm.get('firstName').hasError('required') ? 'Field required' : '';
     }
 
     getLastNameErrorMessage(): string {
-        return this.userForm.get('lastName').hasError('required') ? 'Field required' : '';
+        return this.registerForm.get('lastName').hasError('required') ? 'Field required' : '';
     }
 
     getEmailErrorMessage(): string {
-        return this.userForm.get('email').hasError('required') ? 'Field required' :
-            this.userForm.get('email').hasError('email') ? 'Invalid email.' :
+        return this.registerForm.get('email').hasError('required') ? 'Field required' :
+            this.registerForm.get('email').hasError('email') ? 'Invalid email.' :
                 '';
     }
 
     getPasswordErrorMessage(): string {
-        return this.userForm.get('password').hasError('required') ? 'Field required' :
-            this.userForm.get('password').hasError('minlength') ? 'Password should be longer than ' + MIN_PASSWORD_LENGTH + ' characters.' :
+        return this.registerForm.get('password').hasError('required') ? 'Field required' :
+            this.registerForm.get('password').hasError('minlength') ? 'Password should be longer than ' + MIN_PASSWORD_LENGTH + ' characters.' :
                 '';
     }
 
     getConfirmPasswordErrorMessage(): string {
-        return this.userForm.get('confirmPassword').hasError('required') ? 'Field required' :
-            this.userForm.get('confirmPassword').hasError('passwordValidator') ? 'Passwords does not match.' :
+        return this.registerForm.get('confirmPassword').hasError('required') ? 'Field required' :
+            this.registerForm.get('confirmPassword').hasError('passwordValidator') ? 'Passwords do not match.' :
                 '';
     }
 
     resetRegistration(): void {
+        this.registerForm.reset();
         this.registrationInProgress = false;
+        this.registrationError = undefined;
     }
 
     public register(): void {
+        if (this.registerForm.invalid) {
+            return;
+        }
         this.registrationInProgress = true;
-        const formValue = this.userForm.value;
+        this.registrationError = undefined;
+        const formValue = this.registerForm.value;
+        if (formValue['password'] !== formValue['confirmPassword']) {
+            this.resetRegistration();
+            this.registrationError = 'Passwords don\'t match!';
+            return;
+        }
         this.accountService.register(formValue['email'], formValue['password'], formValue['firstName'], formValue['lastName'])
             .then(() => {
                 this.registrationInProgress = false;
-                this.changePageMode();
-            }, () => {
+                this.changePageMode(LoginPageMode.LOG_IN);
+            }, (error) => {
                 this.resetRegistration();
+                this.registrationError = error.error.details;
             });
     }
 }

--- a/frontend/src/app/pages/login-page/login-page.component.ts
+++ b/frontend/src/app/pages/login-page/login-page.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
-import {FormControl, FormGroup, ValidationErrors, Validators} from '@angular/forms';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {passwordValidator} from '../validators/password-validator.directive';
 import {AccountService} from '../../services/account.service';
 
@@ -48,7 +48,7 @@ export class LoginPageComponent implements OnInit {
         this.loginForm = new FormGroup({
             email: new FormControl(null, [Validators.required, Validators.email]),
             password: new FormControl(null, [Validators.required, Validators.minLength(MIN_PASSWORD_LENGTH)])
-        })
+        });
     }
 
     resetLogin(): void {
@@ -129,8 +129,8 @@ export class LoginPageComponent implements OnInit {
 
     getPasswordErrorMessage(): string {
         return this.registerForm.get('password').hasError('required') ? 'Field required' :
-            this.registerForm.get('password').hasError('minlength') ? 'Password should be longer than ' + MIN_PASSWORD_LENGTH + ' characters.' :
-                '';
+            this.registerForm.get('password').hasError('minlength') ? 'Password should be longer than ' + MIN_PASSWORD_LENGTH
+                + ' characters.' : '';
     }
 
     getConfirmPasswordErrorMessage(): string {
@@ -152,11 +152,6 @@ export class LoginPageComponent implements OnInit {
         this.registrationInProgress = true;
         this.registrationError = undefined;
         const formValue = this.registerForm.value;
-        if (formValue['password'] !== formValue['confirmPassword']) {
-            this.resetRegistration();
-            this.registrationError = 'Passwords don\'t match!';
-            return;
-        }
         this.accountService.register(formValue['email'], formValue['password'], formValue['firstName'], formValue['lastName'])
             .then(() => {
                 this.registrationInProgress = false;


### PR DESCRIPTION
Fixes #373
Fixes #374

## Proposed Changes

  - Login/Registration button will be now disabled up until form is properly filled out.
  - Additionally to error icon, a message describing the error will be displayed.
  - Changed order of Sign In / Sign Up tabs - as we initially start in Sign In tab, I think it'd be more intuitive to have it on the left side.
  - After these changes, clicking on active tab (highlighted in orange) won't change the active tab (which is a thing right now - although not listed in Issues).