### PR TITLE
Fix loading for Scans with low number of Slices

### DIFF
--- a/backend/medtagger/api/scans/service_web_socket.py
+++ b/backend/medtagger/api/scans/service_web_socket.py
@@ -26,10 +26,10 @@ class Slices(Namespace):
         self._raise_on_invalid_request_slices(count, orientation)
 
         orientation = SliceOrientation[orientation]
-        slices = business.get_slices_for_scan(scan_id, begin, count, orientation=orientation)
-        slices_to_send = reversed(list(enumerate(slices))) if reversed_order else enumerate(slices)
-        last_in_batch = begin if reversed_order else begin + count - 1
-        for index, (_slice, image) in slices_to_send:
+        slices = list(business.get_slices_for_scan(scan_id, begin, count, orientation=orientation))
+        slices_to_send = list(reversed(slices)) if reversed_order else slices
+        last_in_batch = begin if reversed_order else begin + len(slices_to_send) - 1
+        for index, (_slice, image) in enumerate(slices_to_send):
             emit('slice', {
                 'scan_id': scan_id,
                 'index': begin + index,

--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -114,7 +114,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
 
     public selectMiddleSlice(): void {
         const slicesCount = this.slider.max - this.slider.min + 1;
-        const middleSliceNumber = this.slider.min + Math.floor(slicesCount / 2) - 1;
+        const middleSliceNumber = this.slider.min + Math.floor(slicesCount / 2);
         this.slider.value = middleSliceNumber;
         this.changeMarkerImage(middleSliceNumber);
         this.drawSelections();

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -98,7 +98,7 @@ export class MarkerPageComponent implements OnInit {
                 this.lastSliceID = slice.index;
             }
             this.marker.feedData(slice);
-            if (slice.isLastInBatch() || (slice.index === this.scan.numberOfSlices - 1)) {
+            if (slice.isLastInBatch()) {
                 if (this.marker.downloadingScanInProgress === true) {
                     this.indicateNewScanAppeared();
                 }

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -98,7 +98,7 @@ export class MarkerPageComponent implements OnInit {
                 this.lastSliceID = slice.index;
             }
             this.marker.feedData(slice);
-            if (slice.isLastInBatch()) {
+            if (slice.isLastInBatch() || (slice.index === this.scan.numberOfSlices - 1)) {
                 if (this.marker.downloadingScanInProgress === true) {
                     this.indicateNewScanAppeared();
                 }

--- a/frontend/src/app/pages/validation-page/validation-page.component.ts
+++ b/frontend/src/app/pages/validation-page/validation-page.component.ts
@@ -42,10 +42,10 @@ export class ValidationPageComponent implements OnInit {
             this.scanViewer.hookUpSliceObserver(ValidationPageComponent.SLICE_BATCH_SIZE).then((isObserverHooked: boolean) => {
                 if (isObserverHooked) {
                     this.scanViewer.observableSliceRequest.subscribe((request: SliceRequest) => {
-                        // TODO: Why is it copied & pasted here? We shoul unify this ASAP!
+                        // TODO: Why is it copied & pasted here? We should unify this ASAP!
                         const reversed = request.reversed;
                         let sliceRequest = request.slice;
-                        console.log('ValiadionPage | observable sliceRequest: ', sliceRequest, ' reversed: ', reversed);
+                        console.log('ValidationPage | observable sliceRequest: ', sliceRequest, ' reversed: ', reversed);
                         let count = ValidationPageComponent.SLICE_BATCH_SIZE;
                         if (reversed === false && sliceRequest + count > this.scan.numberOfSlices) {
                             count = this.scan.numberOfSlices - sliceRequest;


### PR DESCRIPTION
Fixes #405

## Proposed Changes

  - Scans with less than 10 Slices are now properly loaded and displayed. Spinner indicator being stuck is no longer an issue.