### PR TITLE
Fix sending Labels with Brush

### DIFF
--- a/backend/medtagger/api/scans/business.py
+++ b/backend/medtagger/api/scans/business.py
@@ -139,8 +139,6 @@ def _validate_label_elements(elements: List[Dict], files: Dict[str, bytes]) -> N
     for label_element in elements:
         # Each Brush Label Element should have its own image attached
         if label_element['tool'] == LabelTool.BRUSH.value:
-            print('FILES:', files)
-            print('LABEL:', label_element)
             try:
                 files[label_element['image_key']]
             except KeyError:

--- a/backend/medtagger/api/scans/business.py
+++ b/backend/medtagger/api/scans/business.py
@@ -109,8 +109,8 @@ def validate_label_payload(elements: List[Dict], files: Dict[str, bytes]) -> Non
     :param elements: List of JSONs describing elements for a single label
     :param files: mapping of uploaded files (name and content)
     """
-    _validate_files(files)
     _validate_label_elements(elements, files)
+    _validate_files(files)
     _validate_tool(elements)
 
 
@@ -139,6 +139,8 @@ def _validate_label_elements(elements: List[Dict], files: Dict[str, bytes]) -> N
     for label_element in elements:
         # Each Brush Label Element should have its own image attached
         if label_element['tool'] == LabelTool.BRUSH.value:
+            print('FILES:', files)
+            print('LABEL:', label_element)
             try:
                 files[label_element['image_key']]
             except KeyError:

--- a/frontend/src/app/components/selectors/BrushSelector.ts
+++ b/frontend/src/app/components/selectors/BrushSelector.ts
@@ -126,7 +126,7 @@ export class BrushSelector extends SelectorBase<BrushSelection> implements Selec
 
             // when canvas is cleared, we have only our brush selection in canvas
             const selectionImageURL: string = this.canvas.toDataURL();
-            this.selectedArea = new BrushSelection(selectionImageURL, this.currentSlice, this.currentTag.name);
+            this.selectedArea = new BrushSelection(selectionImageURL, this.currentSlice, this.currentTag.key);
 
             this.selectedArea.getSelectionLayer().then((image: HTMLImageElement) => {
                 this.lastTagDrawings[this.getSelectingContext()] = image;
@@ -135,7 +135,7 @@ export class BrushSelector extends SelectorBase<BrushSelection> implements Selec
 
                 if (currentSliceSelections) {
                     const labelTagSelectionIndex: number = currentSliceSelections.findIndex(
-                        (selection: BrushSelection) => selection.label_tag === this.currentTag.name
+                        (selection: BrushSelection) => selection.label_tag === this.currentTag.key
                     );
 
                     if (labelTagSelectionIndex > -1) {
@@ -156,7 +156,7 @@ export class BrushSelector extends SelectorBase<BrushSelection> implements Selec
 
     // To differentiate selections by tags and slices
     private getSelectingContext(): string {
-        return this.currentTag.name + this.currentSlice;
+        return this.currentTag.key + this.currentSlice;
     }
 
     getSelectorName(): string {

--- a/frontend/src/app/model/selections/BrushSelection.ts
+++ b/frontend/src/app/model/selections/BrushSelection.ts
@@ -1,4 +1,5 @@
 import {SliceSelection} from './SliceSelection';
+import {BinaryConverter} from '../../utils/BinaryConverter';
 
 export class BrushSelection extends SliceSelection {
     _selectionLayer: HTMLImageElement;
@@ -41,8 +42,8 @@ export class BrushSelection extends SliceSelection {
     }
 
     getAdditionalData(): Object {
-        let additionalData: Object = {};
-        additionalData[this.getId().toString()] = SliceSelection.base64toBlob(this._selectionLayer.src);
+        const additionalData: Object = {};
+        additionalData[this.getId().toString()] = BinaryConverter.base64toBlob(this._selectionLayer.src);
         return additionalData;
     }
 }

--- a/frontend/src/app/model/selections/BrushSelection.ts
+++ b/frontend/src/app/model/selections/BrushSelection.ts
@@ -18,6 +18,7 @@ export class BrushSelection extends SliceSelection {
 
         this.sliceIndex = depth;
         this.label_tag = tag;
+        this.label_tool = 'BRUSH';
     }
 
     public getSelectionLayer(): Promise<HTMLImageElement | Error> {
@@ -32,10 +33,16 @@ export class BrushSelection extends SliceSelection {
         return {
             'width': 1,
             'height': 1,
-            'image_key': this._selectionLayer.src,
+            'image_key': this.getId().toString(),
             'slice_index': this.sliceIndex,
             'tag': this.label_tag,
             'tool': this.label_tool
         };
+    }
+
+    getAdditionalData(): Object {
+        let additionalData: Object = {};
+        additionalData[this.getId().toString()] = SliceSelection.base64toBlob(this._selectionLayer.src);
+        return additionalData;
     }
 }

--- a/frontend/src/app/model/selections/ScanSelection.ts
+++ b/frontend/src/app/model/selections/ScanSelection.ts
@@ -2,4 +2,5 @@ export interface ScanSelection<SliceSelection> {
     _elements: SliceSelection[];
 
     toJSON(): Object;
+    getAdditionalData(): Object;
 }

--- a/frontend/src/app/model/selections/Selection3D.ts
+++ b/frontend/src/app/model/selections/Selection3D.ts
@@ -27,7 +27,7 @@ export class Selection3D implements ScanSelection<SliceSelection> {
             this._elements.forEach((element: SliceSelection) => {
                 const elementAdditionalData: Object = element.getAdditionalData();
                 additionalData = Object.assign(additionalData, elementAdditionalData);
-            })
+            });
         }
 
         return additionalData;

--- a/frontend/src/app/model/selections/Selection3D.ts
+++ b/frontend/src/app/model/selections/Selection3D.ts
@@ -1,6 +1,5 @@
 import {ScanSelection} from './ScanSelection';
 import {SliceSelection} from './SliceSelection';
-import {element} from "protractor";
 
 export class Selection3D implements ScanSelection<SliceSelection> {
     _elements: SliceSelection[];

--- a/frontend/src/app/model/selections/Selection3D.ts
+++ b/frontend/src/app/model/selections/Selection3D.ts
@@ -1,5 +1,6 @@
 import {ScanSelection} from './ScanSelection';
 import {SliceSelection} from './SliceSelection';
+import {element} from "protractor";
 
 export class Selection3D implements ScanSelection<SliceSelection> {
     _elements: SliceSelection[];
@@ -7,6 +8,7 @@ export class Selection3D implements ScanSelection<SliceSelection> {
     constructor(elements?: SliceSelection[]) {
         this._elements = elements;
     }
+
     toJSON(): Object {
         const jsonObject: { elements: Object[] } = {elements: []};
 
@@ -17,5 +19,18 @@ export class Selection3D implements ScanSelection<SliceSelection> {
         }
 
         return jsonObject;
+    }
+
+    getAdditionalData(): Object {
+        let additionalData = {};
+
+        if (this._elements) {
+            this._elements.forEach((element: SliceSelection) => {
+                const elementAdditionalData: Object = element.getAdditionalData();
+                additionalData = Object.assign(additionalData, elementAdditionalData);
+            })
+        }
+
+        return additionalData;
     }
 }

--- a/frontend/src/app/model/selections/SliceSelection.ts
+++ b/frontend/src/app/model/selections/SliceSelection.ts
@@ -22,14 +22,4 @@ export abstract class SliceSelection {
     public getAdditionalData(): Object {
         return {};
     }
-
-    protected static base64toBlob(base64: string, dataType: string = 'image/png'): Blob {
-        let byteString = atob(base64.split(',')[1]);
-        let buffer = new ArrayBuffer(byteString.length);
-        let array = new Uint8Array(buffer);
-        for (let i = 0; i < byteString.length; i++) {
-            array[i] = byteString.charCodeAt(i);
-        }
-        return new Blob([buffer], {type: dataType});
-    }
 }

--- a/frontend/src/app/model/selections/SliceSelection.ts
+++ b/frontend/src/app/model/selections/SliceSelection.ts
@@ -19,4 +19,17 @@ export abstract class SliceSelection {
     }
 
     public abstract toJSON(): Object;
+    public getAdditionalData(): Object {
+        return {};
+    }
+
+    protected static base64toBlob(base64: string, dataType: string = 'image/png'): Blob {
+        let byteString = atob(base64.split(',')[1]);
+        let buffer = new ArrayBuffer(byteString.length);
+        let array = new Uint8Array(buffer);
+        for (let i = 0; i < byteString.length; i++) {
+            array[i] = byteString.charCodeAt(i);
+        }
+        return new Blob([buffer], {type: dataType});
+    }
 }

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -62,8 +62,8 @@ export class ScanService {
         form.append('label', JSON.stringify(payload));
 
         const additionalData = selection.getAdditionalData();
-        for (let key in additionalData) {
-            let value = additionalData[key];
+        for (const key of Object.keys(additionalData)) {
+            const value = additionalData[key];
             form.append(key, value, key);
         }
 

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -57,8 +57,16 @@ export class ScanService {
         const payload = selection.toJSON();
         payload['labeling_time'] = labelingTime;
         payload['comment'] = comment;
+
         const form = new FormData();
         form.append('label', JSON.stringify(payload));
+
+        const additionalData = selection.getAdditionalData();
+        for (let key in additionalData) {
+            let value = additionalData[key];
+            form.append(key, value, key);
+        }
+
         return new Promise((resolve, reject) => {
             this.http.post(environment.API_URL + `/scans/${scanId}/${taskKey}/label`, form).toPromise().then((response: Response) => {
                 console.log('ScanService | send3dSelection | response: ', response);

--- a/frontend/src/app/utils/BinaryConverter.ts
+++ b/frontend/src/app/utils/BinaryConverter.ts
@@ -1,0 +1,11 @@
+export class BinaryConverter {
+    public static base64toBlob(base64: string, dataType: string = 'image/png'): Blob {
+        const byteString = atob(base64.split(',')[1]);
+        const buffer = new ArrayBuffer(byteString.length);
+        const array = new Uint8Array(buffer);
+        for (let i = 0; i < byteString.length; i++) {
+            array[i] = byteString.charCodeAt(i);
+        }
+        return new Blob([buffer], {type: dataType});
+    }
+}


### PR DESCRIPTION
Fixes #404 

## Proposed Changes

  - Use Tag key instead of name,
  - Send Brush images as files instead of base64 (transfer reduction by ~33%),
  - Allow selections to add files/additional data to the final Label.
