### PR TITLE
Enabled selectors to block mouse scrolling

### DIFF
--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -265,6 +265,10 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
         };
 
         this.canvas.onwheel = (wheelEvent: WheelEvent) => {
+            if (this.currentSelector && !this.currentSelector.canUseMouseWheel()) {
+                return;
+            }
+
             const sliderValue = wheelEvent.deltaY > 0 ? this.slider.value - 1 : this.slider.value + 1;
 
             if (sliderValue >= this.slider.min && sliderValue <= this.slider.max) {

--- a/frontend/src/app/components/selectors/BrushSelector.ts
+++ b/frontend/src/app/components/selectors/BrushSelector.ts
@@ -279,7 +279,11 @@ export class BrushSelector extends SelectorBase<BrushSelection> implements Selec
         return this.canvas.toDataURL() === blankCanvas.toDataURL();
     }
 
-    getSelectorName(): string {
+    public getSelectorName(): string {
         return 'BRUSH';
+    }
+
+    public canUseMouseWheel(): boolean {
+        return !this.mouseDrag;
     }
 }

--- a/frontend/src/app/components/selectors/RectROISelector.ts
+++ b/frontend/src/app/components/selectors/RectROISelector.ts
@@ -91,4 +91,8 @@ export class RectROISelector extends SelectorBase<ROISelection2D> implements Sel
     public getSelectorName(): string {
         return 'RECTANGLE';
     }
+
+    public canUseMouseWheel(): boolean {
+        return !this.selectedArea;
+    }
 }

--- a/frontend/src/app/components/selectors/Selector.ts
+++ b/frontend/src/app/components/selectors/Selector.ts
@@ -64,4 +64,7 @@ export interface Selector<SliceSelection> {
     deselect(): void;
 
     isSingleSelectionPerSlice(): boolean;
+
+    // Used to check if using mouse wheel is safe with current selector
+    canUseMouseWheel(): boolean;
 }

--- a/frontend/src/app/components/selectors/SelectorBase.ts
+++ b/frontend/src/app/components/selectors/SelectorBase.ts
@@ -236,5 +236,9 @@ export abstract class SelectorBase<CustomSliceSelection extends SliceSelection> 
     public deselect(): void {
         // pass
     }
+
+    public canUseMouseWheel(): boolean {
+        return true;
+    }
 }
 


### PR DESCRIPTION
Fixes #396 

## Proposed Changes

  - Selectors now have method returning information to marker about possibility of using mouse wheel with current selector.
  - Blocked mouse wheel events when drawing using BrushSelector and RectROISelector
  - By default selectors allows usage of mouse wheel without constraints
