### PR TITLE
Clear previous Label comment when next Scan is loaded.

### DIFF
--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -188,6 +188,7 @@ export class MarkerPageComponent implements OnInit {
     public nextScan(): void {
         this.marker.setDownloadScanInProgress(true);
         this.marker.prepareForNewScan();
+        this.labelComment = '';
         this.requestScan();
     }
 


### PR DESCRIPTION
Fixes #406

## Proposed Changes

  - Just a quick fix so that Label's Comment does not stay the same in between Scans.
