### PR TITLE
Selection Id is now correctly reset.

### DIFF
--- a/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
+++ b/frontend/src/app/components/scan-viewer/scan-viewer.component.ts
@@ -72,6 +72,7 @@ export class ScanViewerComponent implements OnInit, AfterViewInit {
     ngAfterViewInit() {
         console.log('ScanViewer | ngAfterViewInit');
         this.sliderFocus();
+        SliceSelection.resetIdCounter();
     }
 
     public sliderFocus() {


### PR DESCRIPTION
Fixes #397

## Proposed Changes

  - Next Selection Id was only reset when loading next Scan. Now it'll be also reset when we temporarily switch out of the Labeling page and get back to it later,

