### PR TITLE
Fix/deleting scans

### DIFF
--- a/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
+++ b/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
@@ -24,59 +24,69 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade(): 
     op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
+    op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
+
     op.drop_constraint('fk_Labels_scan_id_Scans', 'Labels')
-    
+    op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
+
     # Droping LabelSelections foreign key (instead of LabelElements) due to naming bug
     op.drop_constraint('fk_LabelSelections_label_id_Labels', 'LabelElements')
-
-    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
-    # Droping PointLabelElement (without 's') due to naming bug
-    op.drop_constraint('fk_PointLabelElement_id_LabelElements', 'PointLabelElements')
-    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
-    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
-    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
-
-    op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
     op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'], ondelete='CASCADE')
-    
+
+    # Droping PointLabelElement (without 's') due to naming bug
+    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
     op.create_foreign_key(
         'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+
+    # Altering primary key name from LabelSelections to LabelElements
+    op.execute('ALTER INDEX "pk_LabelSelections" RENAME TO "pk_LabelElements"')
+
+    op.drop_constraint('fk_PointLabelElement_id_LabelElements', 'PointLabelElements')
     op.create_foreign_key(
         'fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+
+    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
     op.create_foreign_key(
         'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+
+    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
     op.create_foreign_key(
         'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'], ondelete='CASCADE')
+    
+    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
     op.create_foreign_key(
         'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
-    # TODO: PK for LabelElements is LabelSelections
-    # TODO: PK for PointLabelElement is PointLabelElement
 
 def downgrade():
     op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
-    op.drop_constraint('fk_Labels_scan_id_Scans', 'Labels')
-    op.drop_constraint('fk_LabelElements_label_id_Labels', 'LabelElements')
-    
-    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
-    op.drop_constraint('fk_PointLabelElements_id_LabelElements', 'PointLabelElements')
-    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
-    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
-    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
-
     op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'])
+
+    op.drop_constraint('fk_Labels_scan_id_Scans', 'Labels')
     op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'])
+
+    op.drop_constraint('fk_LabelElements_label_id_Labels', 'LabelElements')
     op.create_foreign_key('fk_LabelSelections_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'])
-    
+
+    op.execute('ALTER INDEX "pk_LabelElements" RENAME TO "pk_LabelSelections"')
+
+    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
     op.create_foreign_key(
         'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'])
+
+    op.drop_constraint('fk_PointLabelElements_id_LabelElements', 'PointLabelElements')
     op.create_foreign_key(
         'fk_PointLabelElement_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'])
+
+    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
     op.create_foreign_key(
         'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'])
+
+    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
     op.create_foreign_key(
         'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'])
+
+    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
     op.create_foreign_key(
         'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'])

--- a/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
+++ b/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
@@ -1,0 +1,71 @@
+"""Add cascade delete
+
+Added Cascade delete to:
+- Scan,
+- Slices,
+- Labels,
+- LabelElements,
+- every type of LabelElements for given tool.
+
+Fixed few naming bugs.
+
+Revision ID: 9f2eafdf821e
+Revises: 0707294d0a96
+Create Date: 2018-08-24 20:05:43.171568
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '9f2eafdf821e'
+down_revision = '0707294d0a96'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
+    op.drop_constraint('fk_Labels_scan_id_Scans', 'Labels')
+    
+    # Droping LabelSelections foreign key (instead of LabelElements) due to naming bug
+    op.drop_constraint('fk_LabelSelections_label_id_Labels', 'LabelElements')
+
+    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
+    # Droping PointLabelElement (without 's') due to naming bug
+    op.drop_constraint('fk_PointLabelElement_id_LabelElements', 'PointLabelElements')
+    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
+    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
+    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
+
+    op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'], ondelete='CASCADE')
+    
+    op.create_foreign_key('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    
+
+def downgrade():
+    op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
+    op.drop_constraint('fk_Labels_scan_id_Scans', 'Labels')
+    op.drop_constraint('fk_LabelElements_label_id_Labels', 'LabelElements')
+    
+    op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
+    op.drop_constraint('fk_PointLabelElements_id_LabelElements', 'PointLabelElements')
+    op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
+    op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
+    op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
+
+    op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'])
+    op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'])
+    op.create_foreign_key('fk_LabelSelections_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'])
+    
+    op.create_foreign_key('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key('fk_PointLabelElement_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'])
+    op.create_foreign_key('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'])

--- a/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
+++ b/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
@@ -17,14 +17,13 @@ Create Date: 2018-08-24 20:05:43.171568
 from alembic import op
 import sqlalchemy as sa
 
-
 revision = '9f2eafdf821e'
 down_revision = '0707294d0a96'
 branch_labels = None
 depends_on = None
 
 
-def upgrade(): 
+def upgrade():
     op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
     op.create_foreign_key('fk_Slices_scan_id_Scans', 'Slices', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
 
@@ -33,31 +32,38 @@ def upgrade():
 
     # Droping LabelSelections foreign key (instead of LabelElements) due to naming bug
     op.drop_constraint('fk_LabelSelections_label_id_Labels', 'LabelElements')
-    op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'],
+                          ondelete='CASCADE')
 
     # Droping PointLabelElement (without 's') due to naming bug
     op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
     op.create_foreign_key(
-        'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+        'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'],
+        ondelete='CASCADE')
 
     # Altering primary key name from LabelSelections to LabelElements
     op.execute('ALTER INDEX "pk_LabelSelections" RENAME TO "pk_LabelElements"')
 
     op.drop_constraint('fk_PointLabelElement_id_LabelElements', 'PointLabelElements')
     op.create_foreign_key(
-        'fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+        'fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'],
+        ondelete='CASCADE')
 
     op.drop_constraint('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements')
     op.create_foreign_key(
-        'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+        'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'],
+        ondelete='CASCADE')
 
     op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
     op.create_foreign_key(
-        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'], ondelete='CASCADE')
-    
+        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements',
+        ['label_element_id'], ['id'], ondelete='CASCADE')
+
     op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
     op.create_foreign_key(
-        'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+        'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'],
+        ondelete='CASCADE')
+
 
 def downgrade():
     op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
@@ -85,7 +91,8 @@ def downgrade():
 
     op.drop_constraint('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints')
     op.create_foreign_key(
-        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'])
+        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements',
+        ['label_element_id'], ['id'])
 
     op.drop_constraint('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements')
     op.create_foreign_key(

--- a/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
+++ b/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
@@ -42,12 +42,18 @@ def upgrade():
     op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'], ondelete='CASCADE')
     op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'], ondelete='CASCADE')
     
-    op.create_foreign_key('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
-    
+    op.create_foreign_key(
+        'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key(
+        'fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key(
+        'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key(
+        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'], ondelete='CASCADE')
+    op.create_foreign_key(
+        'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'], ondelete='CASCADE')
+    # TODO: PK for LabelElements is LabelSelections
+    # TODO: PK for PointLabelElement is PointLabelElement
 
 def downgrade():
     op.drop_constraint('fk_Slices_scan_id_Scans', 'Slices')
@@ -64,8 +70,13 @@ def downgrade():
     op.create_foreign_key('fk_Labels_scan_id_Scans', 'Labels', 'Scans', ['scan_id'], ['id'])
     op.create_foreign_key('fk_LabelSelections_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'])
     
-    op.create_foreign_key('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'])
-    op.create_foreign_key('fk_PointLabelElement_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'])
-    op.create_foreign_key('fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'])
-    op.create_foreign_key('fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'])
-    op.create_foreign_key('fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key(
+        'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key(
+        'fk_PointLabelElement_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key(
+        'fk_ChainLabelElements_id_LabelElements', 'ChainLabelElements', 'LabelElements', ['id'], ['id'])
+    op.create_foreign_key(
+        'fk_ChainLabelElementPoints_label_element_id_LabelElements', 'ChainLabelElementPoints', 'LabelElements', ['label_element_id'], ['id'])
+    op.create_foreign_key(
+        'fk_BrushLabelElements_id_LabelElements', 'BrushLabelElements', 'LabelElements', ['id'], ['id'])

--- a/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
+++ b/backend/alembic/versions/9f2eafdf821e_add_cascade_delete_to_scans.py
@@ -35,7 +35,6 @@ def upgrade():
     op.create_foreign_key('fk_LabelElements_label_id_Labels', 'LabelElements', 'Labels', ['label_id'], ['id'],
                           ondelete='CASCADE')
 
-    # Droping PointLabelElement (without 's') due to naming bug
     op.drop_constraint('fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements')
     op.create_foreign_key(
         'fk_RectangularLabelElements_id_LabelElements', 'RectangularLabelElements', 'LabelElements', ['id'], ['id'],
@@ -44,6 +43,7 @@ def upgrade():
     # Altering primary key name from LabelSelections to LabelElements
     op.execute('ALTER INDEX "pk_LabelSelections" RENAME TO "pk_LabelElements"')
 
+    # Dropping PointLabelElement (without 's') due to naming bug
     op.drop_constraint('fk_PointLabelElement_id_LabelElements', 'PointLabelElements')
     op.create_foreign_key(
         'fk_PointLabelElements_id_LabelElements', 'PointLabelElements', 'LabelElements', ['id'], ['id'],

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -178,7 +178,7 @@ class Scan(Base):
     owner: Optional[User] = relationship('User', back_populates='scans')
 
     slices: List['Slice'] = relationship('Slice', back_populates='scan', cascade='delete',
-                                        order_by=lambda: Slice.location)
+                                         order_by=lambda: Slice.location)
     labels: List['Label'] = relationship('Label', back_populates='scan', cascade='delete')
 
     def __init__(self, dataset: Dataset, declared_number_of_slices: int, user: Optional[User]) -> None:
@@ -253,7 +253,7 @@ class Slice(Base):
     width: int = Column(Integer, nullable=True)
     height: int = Column(Integer, nullable=True)
 
-    scan_id: ScanID = Column(String, ForeignKey('Scans.id'))
+    scan_id: ScanID = Column(String, ForeignKey('Scans.id', ondelete='cascade'))
     scan: Scan = relationship('Scan', back_populates='slices')
 
     def __init__(self, orientation: SliceOrientation, location: SliceLocation = None,
@@ -320,7 +320,7 @@ class Label(Base):
 
     __tablename__ = 'Labels'
     id: LabelID = Column(String, primary_key=True)
-    scan_id: ScanID = Column(String, ForeignKey('Scans.id'))
+    scan_id: ScanID = Column(String, ForeignKey('Scans.id', ondelete='cascade'))
     scan: Scan = relationship('Scan', back_populates='labels')
     task_id: TaskID = Column(Integer, ForeignKey('Tasks.id'), nullable=False)
     task: Task = relationship('Task')
@@ -405,7 +405,7 @@ class LabelElement(Base):
 
     slice_index: int = Column(Integer, nullable=False)
 
-    label_id: LabelID = Column(String, ForeignKey('Labels.id'))
+    label_id: LabelID = Column(String, ForeignKey('Labels.id', ondelete='cascade'))
     label: Label = relationship('Label', back_populates='elements')
 
     tag_id: LabelTagID = Column(Integer, ForeignKey('LabelTags.id'))
@@ -449,7 +449,7 @@ class RectangularLabelElement(LabelElement):
     """Definition of a Label Element made with Rectangle Tool."""
 
     __tablename__ = 'RectangularLabelElements'
-    id: LabelElementID = Column(String, ForeignKey('LabelElements.id'), primary_key=True)
+    id: LabelElementID = Column(String, ForeignKey('LabelElements.id', ondelete='cascade'), primary_key=True)
 
     x: float = Column(Float, nullable=False)
     y: float = Column(Float, nullable=False)
@@ -483,7 +483,7 @@ class BrushLabelElement(LabelElement):
     """Definition of a Label Element made with Brush Tool."""
 
     __tablename__ = 'BrushLabelElements'
-    id: LabelElementID = Column(String, ForeignKey('LabelElements.id'), primary_key=True)
+    id: LabelElementID = Column(String, ForeignKey('LabelElements.id', ondelete='cascade'), primary_key=True)
 
     width: int = Column(Integer, nullable=False)
     height: int = Column(Integer, nullable=False)
@@ -514,7 +514,7 @@ class PointLabelElement(LabelElement):
     """Definition of a Label Element made with Point Tool."""
 
     __tablename__ = 'PointLabelElements'
-    id: LabelElementID = Column(String, ForeignKey('LabelElements.id'), primary_key=True)
+    id: LabelElementID = Column(String, ForeignKey('LabelElements.id', ondelete='cascade'), primary_key=True)
 
     x: float = Column(Float, nullable=False)
     y: float = Column(Float, nullable=False)
@@ -543,7 +543,7 @@ class ChainLabelElement(LabelElement):
     """Definition of a Label Element made with Chain Tool."""
 
     __tablename__ = 'ChainLabelElements'
-    id: LabelElementID = Column(String, ForeignKey('LabelElements.id'), primary_key=True)
+    id: LabelElementID = Column(String, ForeignKey('LabelElements.id', ondelete='cascade'), primary_key=True)
 
     points: List['ChainLabelElementPoint'] = relationship('ChainLabelElementPoint',
                                                           order_by='ChainLabelElementPoint.order',
@@ -578,7 +578,8 @@ class ChainLabelElementPoint(Base):
 
     x: float = Column(Float, nullable=False)
     y: float = Column(Float, nullable=False)
-    label_element_id: LabelElementID = Column(String, ForeignKey('LabelElements.id'), nullable=False)
+    label_element_id: LabelElementID = Column(String, ForeignKey('LabelElements.id', ondelete='cascade'),
+                                              nullable=False)
     label_element: ChainLabelElement = relationship('ChainLabelElement', back_populates='points')
     order: int = Column(Integer, nullable=False)
 

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -177,7 +177,8 @@ class Scan(Base):
     owner_id: Optional[int] = Column(Integer, ForeignKey('Users.id'))
     owner: Optional[User] = relationship('User', back_populates='scans')
 
-    slices: List['Slice'] = relationship('Slice', back_populates='scan', cascade='delete', order_by=lambda: Slice.location)
+    slices: List['Slice'] = relationship('Slice', back_populates='scan', cascade='delete',
+                                        order_by=lambda: Slice.location)
     labels: List['Label'] = relationship('Label', back_populates='scan', cascade='delete')
 
     def __init__(self, dataset: Dataset, declared_number_of_slices: int, user: Optional[User]) -> None:

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -6,6 +6,8 @@ from typing import List, Dict, cast, Optional, Any
 from sqlalchemy import Column, Integer, Float, String, ForeignKey, Boolean, Enum, Table, and_, event
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm.mapper import Mapper
 
 from medtagger.database.utils import ArrayOfEnum
 from medtagger.database import Base, db_session
@@ -310,9 +312,10 @@ class Slice(Base):
         return self
 
 
+# pylint: disable=unused-argument
 @event.listens_for(Slice, 'before_delete')
-def delete_original_and_processed_slice_from_storage(target: Any) -> None:
-    """Delete original and processed slices from storage."""
+def delete_original_and_processed_slice_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
+    """Delete original and processed Slices from storage."""
     original_slice = OriginalSlice.get(id=target.id)
     original_slice.delete()
     processed_slice = ProcessedSlice.get(id=target.id)
@@ -520,8 +523,9 @@ class BrushLabelElement(LabelElement):
         return '<{}: {}>'.format(self.__class__.__name__, self.id)
 
 
+# pylint: disable=unused-argument
 @event.listens_for(BrushLabelElement, 'before_delete')
-def delete_brush_element_from_storage(target: Any) -> None:
+def delete_brush_element_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
     """Delete BrushLabelElement from storage."""
     brush_label_element = StorageBrushLabelElement.get(id=target.id)
     brush_label_element.delete()

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -177,8 +177,8 @@ class Scan(Base):
     owner_id: Optional[int] = Column(Integer, ForeignKey('Users.id'))
     owner: Optional[User] = relationship('User', back_populates='scans')
 
-    slices: List['Slice'] = relationship('Slice', back_populates='scan', order_by=lambda: Slice.location)
-    labels: List['Label'] = relationship('Label', back_populates='scan')
+    slices: List['Slice'] = relationship('Slice', back_populates='scan', cascade='delete', order_by=lambda: Slice.location)
+    labels: List['Label'] = relationship('Label', back_populates='scan', cascade='delete')
 
     def __init__(self, dataset: Dataset, declared_number_of_slices: int, user: Optional[User]) -> None:
         """Initialize Scan.
@@ -326,7 +326,7 @@ class Label(Base):
 
     labeling_time: LabelingTime = Column(Float, nullable=True)
 
-    elements: List['LabelElement'] = relationship('LabelElement', back_populates='label')
+    elements: List['LabelElement'] = relationship('LabelElement', back_populates='label', cascade='delete')
 
     owner_id: int = Column(Integer, ForeignKey('Users.id'))
     owner: User = relationship('User', back_populates='labels')

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -5,8 +5,8 @@ from typing import List, Dict, cast, Optional, Any
 
 from sqlalchemy import Column, Integer, Float, String, ForeignKey, Boolean, Enum, Table, and_, event
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import relationship
 from sqlalchemy.engine import Connection
+from sqlalchemy.orm import relationship
 from sqlalchemy.orm.mapper import Mapper
 
 from medtagger.database.utils import ArrayOfEnum
@@ -312,16 +312,6 @@ class Slice(Base):
         return self
 
 
-# pylint: disable=unused-argument
-@event.listens_for(Slice, 'before_delete')
-def delete_original_and_processed_slice_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
-    """Delete original and processed Slices from storage."""
-    original_slice = OriginalSlice.get(id=target.id)
-    original_slice.delete()
-    processed_slice = ProcessedSlice.get(id=target.id)
-    processed_slice.delete()
-
-
 ##########################
 #
 #  Labels related models
@@ -521,14 +511,6 @@ class BrushLabelElement(LabelElement):
     def __repr__(self) -> str:
         """Return string representation for Brush Label Element."""
         return '<{}: {}>'.format(self.__class__.__name__, self.id)
-
-
-# pylint: disable=unused-argument
-@event.listens_for(BrushLabelElement, 'before_delete')
-def delete_brush_element_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
-    """Delete BrushLabelElement from storage."""
-    brush_label_element = StorageBrushLabelElement.get(id=target.id)
-    brush_label_element.delete()
 
 
 class PointLabelElement(LabelElement):
@@ -821,3 +803,21 @@ class SurveyResponse(ActionResponse):
     def get_details(self) -> Dict:
         """Return dictionary details about this Survey Response."""
         return self.data
+
+
+# pylint: disable=unused-argument
+@event.listens_for(BrushLabelElement, 'before_delete')
+def delete_brush_element_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
+    """Delete BrushLabelElement from storage."""
+    brush_label_element = StorageBrushLabelElement.get(id=target.id)
+    brush_label_element.delete()
+
+
+# pylint: disable=unused-argument
+@event.listens_for(Slice, 'before_delete')
+def delete_original_and_processed_slice_from_storage(mapper: Mapper, connection: Connection, target: Slice) -> None:
+    """Delete original and processed Slices from storage."""
+    original_slice = OriginalSlice.get(id=target.id)
+    original_slice.delete()
+    processed_slice = ProcessedSlice.get(id=target.id)
+    processed_slice.delete()

--- a/backend/medtagger/repositories/scans.py
+++ b/backend/medtagger/repositories/scans.py
@@ -42,7 +42,8 @@ def get_random_scan(task: Task = None, user: User = None) -> Scan:
 def delete_scan_by_id(scan_id: ScanID) -> None:
     """Remove Scan from SQL database."""
     with db_session() as session:
-        session.query(Scan).filter(Scan.id == scan_id).delete()
+        scan = session.query(Scan).filter(Scan.id == scan_id).one()
+        session.delete(scan)
 
 
 def add_new_scan(dataset: Dataset, number_of_slices: int, user: Optional[User]) -> Scan:

--- a/backend/tests/functional_tests/test_deleting_scan.py
+++ b/backend/tests/functional_tests/test_deleting_scan.py
@@ -1,0 +1,246 @@
+"""Tests for deleting scans and its elements from database."""
+import json
+from typing import Any
+
+import pytest
+from sqlalchemy.orm.exc import NoResultFound
+
+from medtagger.types import ScanID, SliceID
+from medtagger.definitions import LabelTool
+from medtagger.repositories.scans import delete_scan_by_id
+from medtagger.repositories.slices import get_slice_by_id
+from medtagger.repositories import (
+    datasets as DatasetsRepository,
+    label_tags as LabelTagsRepository,
+    tasks as TasksRepository,
+)
+
+from tests.functional_tests import get_api_client, get_web_socket_client, get_headers
+from tests.functional_tests.conftest import get_token_for_logged_in_user
+
+
+def test_delete_scan_without_slices(prepare_environment: Any, synchronous_celery: Any) -> None:
+    """Test deleting scan without any slices."""
+    api_client = get_api_client()
+    user_token = get_token_for_logged_in_user('admin')
+
+    # Step 1. Prepare a structure for the test
+    DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
+
+    # Step 2. Add Scan to the system
+    payload = {'dataset': 'KIDNEYS', 'number_of_slices': 0}
+    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+                               headers=get_headers(token=user_token, json=True))
+    assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    scan_id: ScanID = json_response['scan_id']
+    assert isinstance(scan_id, str)
+    assert len(scan_id) >= 1
+
+    # Step 3. Get scan
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 200
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    assert json_response['scan_id'] == scan_id
+    assert json_response['number_of_slices'] == 0
+
+    # Step 4. Delete scan from the system
+    delete_scan_by_id(scan_id)
+
+    # Step 5. Check that scan has been deleted
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 404
+
+
+def test_delete_scan_with_slices(prepare_environment: Any, synchronous_celery: Any) -> None:
+    """Test deleting scan with at least 1 slice."""
+    api_client = get_api_client()
+    user_token = get_token_for_logged_in_user('admin')
+
+    # Step 1. Prepare a structure for the test
+    DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
+
+    # Step 2. Add Scan to the system
+    payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
+    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+                               headers=get_headers(token=user_token, json=True))
+    assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    scan_id: ScanID = json_response['scan_id']
+    assert isinstance(scan_id, str)
+    assert len(scan_id) >= 1
+
+    # Step 3. Send slices
+    with open('tests/assets/example_scan/slice_1.dcm', 'rb') as image:
+        response = api_client.post('/api/v1/scans/{}/slices'.format(scan_id), data={
+            'image': (image, 'slice_1.dcm'),
+        }, content_type='multipart/form-data', headers=get_headers(token=user_token))
+        assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    slice_id: SliceID = json_response['slice_id']
+    assert isinstance(slice_id, str)
+    assert len(slice_id) >= 1
+
+    # Step 4. Get scan
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 200
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    assert json_response['scan_id'] == scan_id
+    assert json_response['number_of_slices'] == 1
+    assert json_response['width'] == 512
+    assert json_response['height'] == 512
+
+    # Step 5. Delete scan from the system
+    delete_scan_by_id(scan_id)
+
+    # Step 6. Check that scan has been deleted
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 404
+
+    # Step 7. Check that slices has been deleted
+    with pytest.raises(NoResultFound):
+        get_slice_by_id(slice_id)
+
+
+def test_delete_scan_with_labels(prepare_environment: Any, synchronous_celery: Any) -> None:
+    """Test deleting scan with at least 1 slice and with labels made with all tools."""
+    api_client = get_api_client()
+    web_socket_client = get_web_socket_client(namespace='/slices')
+    user_token = get_token_for_logged_in_user('admin')
+
+    # Step 1. Prepare a structure for the test
+    DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag',
+                                    [LabelTool.RECTANGLE, LabelTool.CHAIN, LabelTool.POINT, LabelTool.BRUSH],
+                                    task.id)
+
+    # Step 2. Add Scan to the system
+    payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
+    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+                               headers=get_headers(token=user_token, json=True))
+    assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    scan_id: ScanID = json_response['scan_id']
+    assert isinstance(scan_id, str)
+    assert len(scan_id) >= 1
+
+    # Step 3. Send slices
+    with open('tests/assets/example_scan/slice_1.dcm', 'rb') as image:
+        response = api_client.post('/api/v1/scans/{}/slices'.format(scan_id), data={
+            'image': (image, 'slice_1.dcm'),
+        }, content_type='multipart/form-data', headers=get_headers(token=user_token))
+        assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    slice_id: SliceID = json_response['slice_id']
+    assert isinstance(slice_id, str)
+    assert len(slice_id) >= 1
+
+    # Step 4. Get scan
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 200
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    assert json_response['scan_id'] == scan_id
+    assert json_response['number_of_slices'] == 1
+    assert json_response['width'] == 512
+    assert json_response['height'] == 512
+
+    # Step 5. Get slices from the server
+    web_socket_client.emit('request_slices', {'scan_id': scan_id, 'begin': 0, 'count': 1}, namespace='/slices')
+    responses = web_socket_client.get_received(namespace='/slices')
+    assert len(responses) == 1
+    response = responses[0]
+    assert response['name'] == 'slice'
+    assert response['args'][0]['scan_id'] == scan_id
+    assert response['args'][0]['index'] == 0
+    assert isinstance(response['args'][0]['image'], bytes)
+
+    # Step 6. Label it with all available tools
+    payload = {
+        'elements': [{
+            'x': 0.5,
+            'y': 0.5,
+            'slice_index': 0,
+            'width': 0.1,
+            'height': 0.1,
+            'tag': 'EXAMPLE_TAG',
+            'tool': LabelTool.RECTANGLE.value,
+        }, {
+            'slice_index': 0,
+            'width': 128,
+            'height': 128,
+            'image_key': 'SLICE_1',
+            'tag': 'EXAMPLE_TAG',
+            'tool': LabelTool.BRUSH.value,
+        }, {
+            'slice_index': 0,
+            'x': 0.25,
+            'y': 0.5,
+            'tag': 'EXAMPLE_TAG',
+            'tool': LabelTool.POINT.value,
+        }, {
+            'slice_index': 0,
+            'points': [
+                {
+                    'x': 0.2,
+                    'y': 0.3,
+                },
+                {
+                    'x': 0.5,
+                    'y': 0.8,
+                },
+            ],
+            'tag': 'EXAMPLE_TAG',
+            'tool': LabelTool.CHAIN.value,
+            'loop': False,
+        }],
+        'labeling_time': 12.34,
+    }
+    with open('tests/assets/example_labels/binary_mask.png', 'rb') as image:
+        data = {
+            'label': json.dumps(payload),
+            'SLICE_1': (image, 'slice_1'),
+        }
+        response = api_client.post('/api/v1/scans/{}/MARK_KIDNEYS/label'.format(scan_id), data=data,
+                                   headers=get_headers(token=user_token, multipart=True))
+
+    assert response.status_code == 201
+    json_response = json.loads(response.data)
+    assert isinstance(json_response, dict)
+    label_id = json_response['label_id']
+    assert isinstance(label_id, str)
+    assert len(label_id) >= 1
+
+    # Step 7. Delete scan from the system
+    delete_scan_by_id(scan_id)
+
+    # Step 8. Check that scan has been deleted
+    response = api_client.get('/api/v1/scans/{}'.format(scan_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 404
+
+    # Step 9. Check that slices has been deleted
+    with pytest.raises(NoResultFound):
+        get_slice_by_id(slice_id)
+
+    # Step 10. Check that labels has been deleted
+    response = api_client.get('/api/v1/labels/{}'.format(label_id),
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 404

--- a/backend/tests/functional_tests/test_deleting_scan.py
+++ b/backend/tests/functional_tests/test_deleting_scan.py
@@ -116,6 +116,7 @@ def test_delete_scan_with_slices(prepare_environment: Any, synchronous_celery: A
         SliceRepository.get_slice_by_id(slice_id)
 
 
+# pylint: disable=too-many-locals
 def test_delete_scan_with_labels(prepare_environment: Any, synchronous_celery: Any) -> None:
     """Test deleting scan with at least 1 slice and with labels made with all tools."""
     api_client = get_api_client()


### PR DESCRIPTION
Fixes #411

## Proposed Changes

  - Added cascade delete option to database model so if a scan is deleted, the slices, labels and all of the labels element is also deleted,
- Introduced deleting of items from Cassandra (deleting Slices items are triggeted before deletion of Slices and deleting BrushLabelElement is triggered before deletion of such Label),
- Fixed few naming bugs
- Created tests for 3 different scenarios when deleting scans,

## Additional comment (optional)

Deleting of the scans were impossible because deleting Scan violated key constraint for Slices. The same thing happened when there was at least one Label and therefore at least one LabelElement.
