### PR TITLE
Fix issue with label's comment and it's edit mode

### DIFF
--- a/frontend/src/app/dialogs/all.dialog.scss
+++ b/frontend/src/app/dialogs/all.dialog.scss
@@ -1,10 +1,14 @@
-p {
+p.dialog__content {
     font-family: Roboto, "Helvetica Neue", sans-serif;
-    margin-top: 0;
+    margin: 1em 0 0;
 }
 
 .mat-dialog-title {
-    margin: 0 0 0 0;
+    margin: 0;
+}
+
+textarea {
+    overflow-y: hidden;
 }
 
 .mat-dialog-content {

--- a/frontend/src/app/dialogs/info-dialog.component.html
+++ b/frontend/src/app/dialogs/info-dialog.component.html
@@ -1,6 +1,6 @@
 <h1 mat-dialog-title>{{data.title}}</h1>
 <div mat-dialog-content>
-    <p>{{data.content}}</p>
+    <p class="dialog__content">{{data.content}}</p>
 </div>
 <div mat-dialog-actions align="center">
     <button mat-raised-button color="primary" (click)="closeDialog()" cdkFocusInitial>{{data.buttonText}}</button>

--- a/frontend/src/app/dialogs/input-dialog.component.html
+++ b/frontend/src/app/dialogs/input-dialog.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>{{data.title}}</h1>
 <div mat-dialog-content>
-    <p>{{data.content}}</p>
+    <p class="dialog__content">{{data.content}}</p>
     <mat-form-field style="width: 100%;">
-        <textarea matInput matTextareaAutosize [formControl]="userInput" placeholder="{{data.input}}"></textarea>
+        <textarea matInput matTextareaAutosize [formControl]="userInput" [(value)]="data.input" rows="1"></textarea>
     </mat-form-field>
 </div>
 <div mat-dialog-actions align="center">

--- a/frontend/src/app/dialogs/input-dialog.component.ts
+++ b/frontend/src/app/dialogs/input-dialog.component.ts
@@ -9,10 +9,11 @@ import {FormControl} from '@angular/forms';
 })
 export class InputDialogComponent {
 
-    userInput = new FormControl('', []);
+    userInput: FormControl;
 
     constructor(private dialogRef: MatDialogRef<InputDialogComponent>,
                 @Inject(MAT_DIALOG_DATA) public data: { title: string, content: string, input: string, buttonText: string }) {
+        this.userInput = new FormControl(data.input);
     }
 
     closeDialog(): void {

--- a/frontend/src/app/pages/marker-page/marker-page.component.ts
+++ b/frontend/src/app/pages/marker-page/marker-page.component.ts
@@ -282,8 +282,8 @@ export class MarkerPageComponent implements OnInit {
 
     public addLabelComment(): void {
         this.marker.setFocusable(false);
-        this.dialogService.openInputDialog('Add comment to your label (optional)', 'If you\'d like, you can add a comment to the label' +
-            ' below:', this.labelComment, 'Add comment').afterClosed().subscribe(comment => {
+        this.dialogService.openInputDialog('Add comment to your label (optional)', '',
+            this.labelComment, this.labelComment ? 'Save comment' : 'Add comment').afterClosed().subscribe(comment => {
                 this.labelComment = comment;
                 this.marker.setFocusable(true);
         });


### PR DESCRIPTION
Fixes #385 


## Proposed Changes

  - I removed previous additional content of dialog (I think it was just repetition of the dialog's title)
  - I fixed the issue with a previous comment being a label - now it is just a new value of the textarea
  - I fixed an issue when a User made no changes to the comment it was deleted
  - when editing a comment now the button will CTA "Save comment" not "Add comment"

## UI changes (optional)

![image](https://user-images.githubusercontent.com/22871925/45055906-8f8e1500-b091-11e8-961c-0ca9e783eaba.png)

