### PR TITLE
Fix issue with HTTP Error 500 thrown when provided non-existing task key

### DIFF
--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -21,7 +21,7 @@ def get_task_by_key(key: str) -> Task:
     :return: Task object
     """
     with db_session() as session:
-        task = session.query(Task).filter(Task.key == key).one()
+        task = session.query(Task).filter(Task.key == key).first()
     return task
 
 


### PR DESCRIPTION
Fixes #417

## Proposed Changes

  - Trying to get scans for non-existing task key will now result in HTTP error 400, rather than 500. 
  
## Additional comment (optional)

Everything was already handled on the backend side, apart from that one minor thingy...
