### PR TITLE
Validate Tags existance in Tasks

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -116,6 +116,9 @@ functional_tests__run:
 	
 functional_tests__delete_environment:
 	. $(FUNCTIONAL_TESTS_MODULE)/configuration.sh && alembic downgrade base
+	make functional_tests__clear_dependencies
+
+functional_tests__clear_dependencies:
 	docker-compose -f $(FUNCTIONAL_TESTS_DOCKER_COMPOSE) down
 
 functional_tests_docker:

--- a/backend/medtagger/api/scans/service_rest.py
+++ b/backend/medtagger/api/scans/service_rest.py
@@ -132,7 +132,7 @@ class Label(Resource):
             best_error = best_match(errors)
             raise InvalidArgumentsException(best_error.message)
 
-        business.validate_label_payload(elements, files)
+        business.validate_label_payload(label, task_key, files)
 
         labeling_time = label['labeling_time']
         comment = label.get('comment')

--- a/backend/tests/functional_tests/test_tools_and_tags.py
+++ b/backend/tests/functional_tests/test_tools_and_tags.py
@@ -49,9 +49,9 @@ def test_add_label_non_existing_tag(prepare_environment: Any) -> None:
     response = api_client.post('/api/v1/scans/{}/MARK_KIDNEYS/label'.format(scan_id),
                                data={'label': json.dumps(payload)},
                                headers=get_headers(token=user_token, multipart=True))
-    assert response.status_code == 404
+    assert response.status_code == 400
     json_response = json.loads(response.data)
-    assert json_response['details'] == 'Could not find any Label Tag for that key!'
+    assert json_response['details'] == 'Tag NON_EXISTING is not part of Task MARK_KIDNEYS.'
 
 
 def test_add_label_non_supported_tool(prepare_environment: Any) -> None:


### PR DESCRIPTION
Fixes #434 

## Proposed Changes

  - Added `functional_tests__clear_dependencies` Makefile entrypoint which simplifies life by removing all Docker containers used in Functional Tests,
  - Refactor Label & Label Elements validation a little bit,
  - Add test that checks for Tag existance in Task.
