### PR TITLE
Fix labeling with different Tag

### DIFF
--- a/frontend/src/app/components/marker/marker.component.ts
+++ b/frontend/src/app/components/marker/marker.component.ts
@@ -105,6 +105,7 @@ export class MarkerComponent extends ScanViewerComponent implements OnInit {
     public setCurrentTag(tag: LabelTag) {
         super.setCurrentTag(tag);
         this.currentTag = tag;
+        this.updateTagForCurrentTool(this.currentTag);
     }
 
     public setDownloadScanInProgress(isInProgress: boolean) {


### PR DESCRIPTION
## Proposed Changes

  - Update Tag in currently selected Tool on each Tag change.

## Comment

This change fixes issue when user wanted to label Scan with different Tag but did not change used Tool.
