### PR TITLE
Fix incorrect usage of slashes

### DIFF
--- a/backend/medtagger/api/scans/service_rest.py
+++ b/backend/medtagger/api/scans/service_rest.py
@@ -17,7 +17,7 @@ from medtagger.api.scans.serializers import elements_schema
 scans_ns = api.namespace('scans', 'Methods related with scans')
 
 
-@scans_ns.route('/')
+@scans_ns.route('')
 class Scans(Resource):
     """Endpoint that can create new scan."""
 

--- a/backend/medtagger/api/users/service.py
+++ b/backend/medtagger/api/users/service.py
@@ -14,7 +14,7 @@ from medtagger.api.security import login_required, role_required
 users_ns = api.namespace('users', 'Users management')
 
 
-@users_ns.route('/')
+@users_ns.route('')
 class GetUsers(Resource):
     """Get all users endpoint."""
 

--- a/backend/tests/functional_tests/test_adding_new_label.py
+++ b/backend/tests/functional_tests/test_adding_new_label.py
@@ -26,7 +26,7 @@ def test_add_brush_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -81,7 +81,7 @@ def test_add_point_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -132,7 +132,7 @@ def test_add_chain_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -195,7 +195,7 @@ def test_add_chain_label_not_enough_points(prepare_environment: Any, synchronous
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -239,7 +239,7 @@ def test_add_label_with_tag_from_other_task(prepare_environment: Any, synchronou
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/backend/tests/functional_tests/test_basic_flow.py
+++ b/backend/tests/functional_tests/test_basic_flow.py
@@ -38,7 +38,7 @@ def test_basic_flow(prepare_environment: Any, synchronous_celery: Any) -> None:
 
     # Step 3. Add Scan to the system
     payload = {'dataset': dataset_key, 'number_of_slices': 1}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -162,7 +162,7 @@ def test_basic_flow_with_predefined_label(prepare_environment: Any, synchronous_
 
     # Step 3. Add Scan to the system
     payload = {'dataset': dataset_key, 'number_of_slices': 1}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/backend/tests/functional_tests/test_deleting_scan.py
+++ b/backend/tests/functional_tests/test_deleting_scan.py
@@ -32,7 +32,7 @@ def test_delete_scan_without_slices(prepare_environment: Any, synchronous_celery
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 0}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -71,7 +71,7 @@ def test_delete_scan_with_slices(prepare_environment: Any, synchronous_celery: A
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -132,7 +132,7 @@ def test_delete_scan_with_labels(prepare_environment: Any, synchronous_celery: A
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/backend/tests/functional_tests/test_scan_upload.py
+++ b/backend/tests/functional_tests/test_scan_upload.py
@@ -29,7 +29,7 @@ def test_scan_upload_and_conversion(prepare_environment: Any, synchronous_celery
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     json_response = json.loads(response.data)
     scan_id = json_response['scan_id']
@@ -83,7 +83,7 @@ def test_scan_upload_with_retrying(fixture_problems_with_storage: Any, prepare_e
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     json_response = json.loads(response.data)
     scan_id = json_response['scan_id']

--- a/backend/tests/functional_tests/test_skipping_a_scan.py
+++ b/backend/tests/functional_tests/test_skipping_a_scan.py
@@ -18,7 +18,7 @@ def test_skipping_a_scan(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/backend/tests/functional_tests/test_tools_and_tags.py
+++ b/backend/tests/functional_tests/test_tools_and_tags.py
@@ -27,7 +27,7 @@ def test_add_label_non_existing_tag(prepare_environment: Any) -> None:
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -66,7 +66,7 @@ def test_add_label_non_supported_tool(prepare_environment: Any) -> None:
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -106,7 +106,7 @@ def test_add_label_missing_tag(prepare_environment: Any) -> None:
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -145,7 +145,7 @@ def test_add_label_missing_tool(prepare_environment: Any) -> None:
 
     # Step 2. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)
@@ -184,7 +184,7 @@ def test_add_label_wrong_tool_for_tag(prepare_environment: Any) -> None:
 
     # Step 1. Add Scan to the system
     payload = {'dataset': 'KIDNEYS', 'number_of_slices': 3}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/backend/tests/functional_tests/test_users.py
+++ b/backend/tests/functional_tests/test_users.py
@@ -82,7 +82,7 @@ def test_upgrade_to_doctor_role(prepare_environment: Any) -> None:
     assert len(admin_user_token) > 100
 
     # Step 2. Admin gets all users
-    response = api_client.get('/api/v1/users/', headers=get_headers(token=admin_user_token))
+    response = api_client.get('/api/v1/users', headers=get_headers(token=admin_user_token))
     assert response.status_code == 200
     json_response = json.loads(response.data)
     assert isinstance(json_response, dict)
@@ -132,7 +132,7 @@ def test_ownership(prepare_environment: Any, synchronous_celery: Any) -> None:
 
     # Step 3. Add Scan to the system
     payload = {'dataset': 'LUNGS', 'number_of_slices': 1}
-    response = api_client.post('/api/v1/scans/', data=json.dumps(payload),
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
                                headers=get_headers(token=admin_user_token, json=True))
     assert response.status_code == 201
     json_response = json.loads(response.data)

--- a/frontend/src/app/services/scan.service.spec.ts
+++ b/frontend/src/app/services/scan.service.spec.ts
@@ -34,12 +34,13 @@ describe('Service: ScanService', () => {
     };
 
     const SEND_SELECTION_API = API_URL.SCANS
+        + '/'
         + EXAMPLE_DATA.SCAN_ID
         + '/'
         + EXAMPLE_DATA.TASK_KEY
         + '/label';
 
-    const SKIP_SCAN_API = API_URL.SCANS + EXAMPLE_DATA.SCAN_ID + API_URL.SKIP;
+    const SKIP_SCAN_API = API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID + API_URL.SKIP;
 
     const MOCK_SCAN_METADATA: ScanMetadata = new ScanMetadata(EXAMPLE_DATA.SCAN_ID,
         EXAMPLE_DATA.STATUS, 50, 512, 512, null);
@@ -211,9 +212,9 @@ describe('Service: ScanService', () => {
             };
 
             backend.expectOne((req: HttpRequest<any>) => {
-                return req.url === environment.API_URL + API_URL.SCANS + EXAMPLE_DATA.SCAN_ID
+                return req.url === environment.API_URL + API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID
                     && req.method === 'GET';
-            }, `GET from ${API_URL.SCANS + EXAMPLE_DATA.SCAN_ID}`)
+            }, `GET from ${API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID}`)
                 .flush(response,
                     {status: 200, statusText: 'Ok'});
         }
@@ -226,9 +227,9 @@ describe('Service: ScanService', () => {
             });
 
             backend.expectOne((req: HttpRequest<any>) => {
-                return req.url === environment.API_URL + API_URL.SCANS + EXAMPLE_DATA.SCAN_ID
+                return req.url === environment.API_URL + API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID
                     && req.method === 'GET';
-            }, `GET from ${API_URL.SCANS + EXAMPLE_DATA.SCAN_ID}`)
+            }, `GET from ${API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID}`)
                 .flush({},
                     {status: 404, statusText: 'No Scans available'});
         }
@@ -342,7 +343,7 @@ describe('Service: ScanService', () => {
 
     it('should upload slices', async(inject([ScanService],
         (service: ScanService) => {
-            const apiUrl = environment.API_URL + API_URL.SCANS + EXAMPLE_DATA.SCAN_ID + API_URL.SLICES;
+            const apiUrl = environment.API_URL + API_URL.SCANS + '/' + EXAMPLE_DATA.SCAN_ID + API_URL.SLICES;
 
             spyOn(http, 'post').and.callFake((api: string, form: FormData) => {
                 if (api === apiUrl && form.has('image')) {

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -5,6 +5,7 @@ import {HttpClient, HttpParams, HttpErrorResponse} from '@angular/common/http';
 import {ScanMetadata} from '../model/ScanMetadata';
 import {MarkerSlice} from '../model/MarkerSlice';
 
+import {API_URL} from '../utils/ApiUrl';
 import {environment} from '../../environments/environment';
 import {ScanSelection} from '../model/selections/ScanSelection';
 import {SliceSelection} from '../model/selections/SliceSelection';
@@ -73,7 +74,7 @@ export class ScanService {
         }
 
         return new Promise((resolve, reject) => {
-            this.http.post(environment.API_URL + `/scans/${scanId}/${taskKey}/label`, form).toPromise().then((response: Response) => {
+            this.http.post(environment.API_URL + API_URL.SCANS + `/${scanId}/${taskKey}/label`, form).toPromise().then((response: Response) => {
                 console.log('ScanService | send3dSelection | response: ', response);
                 resolve(response);
             }).catch((error: Response) => {
@@ -93,7 +94,7 @@ export class ScanService {
         }
 
         return new Promise((resolve, reject) => {
-            this.http.post(environment.API_URL + `/scans/${scanId}/${taskKey}/label?is_predefined=true`, form).toPromise()
+            this.http.post(environment.API_URL + API_URL.SCANS + `/${scanId}/${taskKey}/label?is_predefined=true`, form).toPromise()
                 .then((response: Response) => {
                     console.log('ScanService | sendPredefinedLabel | response: ', response);
                     resolve(response);
@@ -111,7 +112,7 @@ export class ScanService {
         return new Promise((resolve, reject) => {
             let params = new HttpParams();
             params = params.set('task', taskKey);
-            this.http.get<ScanResponse>(environment.API_URL + '/scans/random', {params: params})
+            this.http.get<ScanResponse>(environment.API_URL + API_URL.SCANS + '/random', {params: params})
                 .subscribe(
                     (response: ScanResponse) => {
                         console.log('ScanService | getRandomScan | response: ', response);
@@ -130,7 +131,7 @@ export class ScanService {
 
     getScanForScanId(scanId: string): Promise<ScanMetadata> {
         return new Promise((resolve, reject) => {
-            this.http.get<ScanResponse>(environment.API_URL + '/scans/' + scanId).toPromise().then(
+            this.http.get<ScanResponse>(environment.API_URL + API_URL.SCANS + '/' + scanId).toPromise().then(
                 (response: ScanResponse) => {
                     console.log('ScanService | getScanForScanId | response: ', response);
                     resolve(new ScanMetadata(response.scan_id, response.status, response.number_of_slices,
@@ -178,7 +179,7 @@ export class ScanService {
                 number_of_slices: numberOfSlices,
             };
             let retryAttempt = 0;
-            this.http.post<NewScanResponse>(environment.API_URL + '/scans/', payload)
+            this.http.post<NewScanResponse>(environment.API_URL + API_URL.SCANS, payload)
                 .pipe(
                     retryWhen((error: Observable<HttpErrorResponse>) => {
                         return error.pipe(
@@ -212,7 +213,7 @@ export class ScanService {
                 const form = new FormData();
                 form.append('image', file, file.name);
                 return defer(
-                    () => this.http.post(environment.API_URL + '/scans/' + scanId + '/slices', form)
+                    () => this.http.post(environment.API_URL + API_URL.SCANS + '/' + scanId + '/slices', form)
                         .pipe(
                             retryWhen((error: Observable<HttpErrorResponse>) => {
                                 return error.pipe(
@@ -235,7 +236,7 @@ export class ScanService {
 
     skipScan(scanId: string): Promise<Response> {
         return new Promise((resolve, reject) => {
-            this.http.post(environment.API_URL + `/scans/${scanId}/skip`, {}).toPromise().then((response: Response) => {
+            this.http.post(environment.API_URL + API_URL.SCANS + `/${scanId}/skip`, {}).toPromise().then((response: Response) => {
                 console.log('ScanService | skipScan | response: ', response);
                 resolve(response);
             }).catch((error: Response) => {

--- a/frontend/src/app/services/scan.service.ts
+++ b/frontend/src/app/services/scan.service.ts
@@ -74,13 +74,14 @@ export class ScanService {
         }
 
         return new Promise((resolve, reject) => {
-            this.http.post(environment.API_URL + API_URL.SCANS + `/${scanId}/${taskKey}/label`, form).toPromise().then((response: Response) => {
-                console.log('ScanService | send3dSelection | response: ', response);
-                resolve(response);
-            }).catch((error: Response) => {
-                console.log('ScanService | send3dSelection | error: ', error);
-                reject(error);
-            });
+            this.http.post(environment.API_URL + API_URL.SCANS + `/${scanId}/${taskKey}/label`, form).toPromise()
+                .then((response: Response) => {
+                    console.log('ScanService | send3dSelection | response: ', response);
+                    resolve(response);
+                }).catch((error: Response) => {
+                    console.log('ScanService | send3dSelection | error: ', error);
+                    reject(error);
+                });
         });
     }
 

--- a/frontend/src/app/services/users.service.spec.ts
+++ b/frontend/src/app/services/users.service.spec.ts
@@ -22,7 +22,7 @@ describe('Service: UsersService', () => {
         settings: USER_SETTINGS
     };
 
-    const SET_DETAILS_API = API_URL.USERS + EXAMPLE_USER.id;
+    const SET_DETAILS_API = API_URL.USERS + '/' + EXAMPLE_USER.id;
     const SET_ROLE_API = SET_DETAILS_API + API_URL.ROLE;
     const SET_SETTINGS_API = SET_DETAILS_API + API_URL.SETTINGS;
 
@@ -141,11 +141,11 @@ describe('Service: UsersService', () => {
 
                 payload = req.body;
 
-                return req.url === environment.API_URL + API_URL.USERS + EXAMPLE_USER.id
+                return req.url === environment.API_URL + API_URL.USERS + '/' + EXAMPLE_USER.id
                     && req.method === 'PUT'
                     && payload.firstName === EXAMPLE_USER.firstName
                     && payload.lastName === EXAMPLE_USER.lastName;
-            }, `PUT to ${environment.API_URL + API_URL.USERS + EXAMPLE_USER.id}`)
+            }, `PUT to ${environment.API_URL + API_URL.USERS + '/' + EXAMPLE_USER.id}`)
                 .flush({},
                     {status: 200, statusText: 'Ok'});
 

--- a/frontend/src/app/services/users.service.ts
+++ b/frontend/src/app/services/users.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@angular/common/http';
 import {UserInfo} from '../model/UserInfo';
 import {environment} from '../../environments/environment';
 import {UserSettings} from '../model/UserSettings';
+import {API_URL} from '../utils/ApiUrl';
 
 interface AllUsersResponse {
     users: Array<UserInfo>;
@@ -14,7 +15,7 @@ export class UsersService {
     }
 
     public getAllUsers(): Promise<Array<UserInfo>> {
-        const url = environment.API_URL + '/users/';
+        const url = environment.API_URL + API_URL.USERS;
         return new Promise<Array<UserInfo>>((resolve, reject) => {
             this.http.get<AllUsersResponse>(url)
                 .toPromise()
@@ -33,7 +34,7 @@ export class UsersService {
     }
 
     public setRole(userId: number, role: string): Promise<void> {
-        const url = environment.API_URL + `/users/${userId}/role`;
+        const url = environment.API_URL + API_URL.USERS + `/${userId}/role`;
         const payload = {
             role: role
         };
@@ -52,7 +53,7 @@ export class UsersService {
     }
 
     public setUserDetails(userId: number, userFirstName: string, userLastName: string): Promise<void> {
-        const url = environment.API_URL + `/users/${userId}`;
+        const url = environment.API_URL + API_URL.USERS + `/${userId}`;
         const payload = {
             firstName: userFirstName,
             lastName: userLastName
@@ -72,7 +73,7 @@ export class UsersService {
     }
 
     public setUserSettings(userId: number, settings: UserSettings): Promise<void> {
-        const url = environment.API_URL + `/users/${userId}/settings`;
+        const url = environment.API_URL + API_URL.USERS + `/${userId}/settings`;
         return new Promise<void>((resolve, reject) => {
             // properties with the undefined value will not be sent
             // only necessary properties of variable 'settings' should be specified

--- a/frontend/src/app/utils/ApiUrl.ts
+++ b/frontend/src/app/utils/ApiUrl.ts
@@ -5,12 +5,12 @@ export enum API_URL {
     DATASETS = '/datasets',
     LABELS = '/labels',
     RANDOM_SCAN = '/scans/random',
-    SCANS = '/scans/',
+    SCANS = '/scans',
     SLICES = '/slices',
     SKIP = '/skip',
     TASK = '/tasks/',
     TASKS = '/tasks',
-    USERS = '/users/',
+    USERS = '/users',
     ROLE = '/role',
     SETTINGS = '/settings'
 }


### PR DESCRIPTION
Fixes #472 

## Proposed Changes

  - Remove all slashes from the end of URL,
  - Change hardcoded API endpoints to `API_URL` enum in frontend.

## API changes

- `/api/v1/scans/` -> `/api/v1/scans`
- `/api/v1/users/` -> `/api/v1/users`