### PR TITLE
Disable warnings and fix WebSocket CORS

### DIFF
--- a/backend/medtagger/api/__init__.py
+++ b/backend/medtagger/api/__init__.py
@@ -23,7 +23,7 @@ authorizations = {
 blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
 api = Api(blueprint, version='0.1', title='Backend API', description='Documentation for Backend API',
           default='core', default_label='Core methods', authorizations=authorizations, validate=True)
-web_socket = SocketIO(logger=True, engineio_logger=True)
+web_socket = SocketIO(logger=True, engineio_logger=True, cors_allowed_origins=True)
 
 
 @api.errorhandler

--- a/backend/medtagger/api/security.py
+++ b/backend/medtagger/api/security.py
@@ -50,7 +50,7 @@ def require_one_of_roles(required_roles: Set[str]) -> None:
 
 def hash_password(password: str) -> str:
     """Hash given password."""
-    return pwd_context.encrypt(password)
+    return pwd_context.hash(password)
 
 
 def verify_user_password(user: User, password: str) -> bool:

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+# Filtered cases:
+# - internal Alembic Deprecation Warning. Please remove one this bug will be removed:
+#   https://bitbucket.org/zzzeek/alembic/issues/507/deprecationwarning-for
+# - Cassandra Deprecation Warning which cannot be removed until this bug will be removed:
+#   https://datastax-oss.atlassian.net/browse/PYTHON-1009
+filterwarnings =
+    ignore:.*formatargspec.*:DeprecationWarning
+    ignore:.*execution profiles.*:DeprecationWarning
+


### PR DESCRIPTION
## Proposed Changes

  - Disable warnings that cannot be resolved without new versions of external depencencies,
  - Fix deprecation warning about `encrypt` method in passlib,
  - Fix WebSocket CORS settings.
